### PR TITLE
feat/Ls-23: 스페이스 회원 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,9 @@ project(":layer-external") {
     bootJar.enabled = false
     jar.enabled = true
 
-	dependencies {
-		implementation project(path: ':layer-common')
-		implementation project(path: ':layer-domain')
+    dependencies {
+        implementation project(path: ':layer-common')
+        implementation project(path: ':layer-domain')
 
         testImplementation platform('org.junit:junit-bom:5.9.1')
         testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/layer-api/src/main/java/org/layer/domain/space/api/SpaceApi.java
+++ b/layer-api/src/main/java/org/layer/domain/space/api/SpaceApi.java
@@ -74,8 +74,8 @@ public interface SpaceApi {
             """)
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = {
-                    @Content(mediaType = "application/json", schema = @Schema(implementation = SpaceResponse.SpaceWithUserCountInfo.class))
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = SpaceResponse.SpaceWithMemberCountInfo.class))
             })
     })
-    ResponseEntity<SpaceResponse.SpaceWithUserCountInfo> getSpaceById(@MemberId Long memberId, @PathVariable Long spaceId);
+    ResponseEntity<SpaceResponse.SpaceWithMemberCountInfo> getSpaceById(@MemberId Long memberId, @PathVariable Long spaceId);
 }

--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
@@ -42,7 +42,7 @@ public class SpaceController implements SpaceApi {
     }
 
     @GetMapping("/{spaceId}")
-    public ResponseEntity<SpaceResponse.SpaceWithUserCountInfo> getSpaceById(@MemberId Long memberId, @PathVariable Long spaceId) {
+    public ResponseEntity<SpaceResponse.SpaceWithMemberCountInfo> getSpaceById(@MemberId Long memberId, @PathVariable Long spaceId) {
         var foundSpace = spaceService.getSpaceById(memberId, spaceId);
         return ResponseEntity.ok((foundSpace));
     }

--- a/layer-api/src/main/java/org/layer/domain/space/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/dto/SpaceResponse.java
@@ -14,11 +14,11 @@ import java.util.Optional;
 import static org.layer.domain.auth.exception.TokenExceptionType.INVALID_REFRESH_TOKEN;
 
 public class SpaceResponse {
-  
+
 
     @Builder
     @Schema(description = "스페이스 정보 응답")
-    public record SpaceWithUserCountInfo(
+    public record SpaceWithMemberCountInfo(
             @Schema(description = "스페이스 ID")
             @NotNull
             Long id,
@@ -40,13 +40,13 @@ public class SpaceResponse {
             Long formId,
 
             @Schema(description = "소속된 회원 수")
-            Long userCount
+            Long memberCount
     ) {
-        public static SpaceWithUserCountInfo toResponse(SpaceWithMemberCount space) {
+        public static SpaceWithMemberCountInfo toResponse(SpaceWithMemberCount space) {
             return Optional.ofNullable(space)
-                    .map(it -> SpaceWithUserCountInfo.builder().id(it.getId()).category(it.getCategory())
+                    .map(it -> SpaceWithMemberCountInfo.builder().id(it.getId()).category(it.getCategory())
                             .field(it.getField()).name(it.getName()).introduction(it.getIntroduction())
-                            .formId(it.getFormId()).userCount(it.getUserCount()).build())
+                            .formId(it.getFormId()).memberCount(it.getMemberCount()).build())
                     .orElseThrow(() -> new BaseCustomException(INVALID_REFRESH_TOKEN));
         }
     }
@@ -55,13 +55,13 @@ public class SpaceResponse {
     @Schema()
     public record SpacePage(
             @Schema()
-            List<SpaceWithUserCountInfo> data,
+            List<SpaceWithMemberCountInfo> data,
 
             @Schema()
             Meta meta
     ) {
 
-        public static SpacePage toResponse(List<SpaceWithUserCountInfo> spaceInfo, Meta meta) {
+        public static SpacePage toResponse(List<SpaceWithMemberCountInfo> spaceInfo, Meta meta) {
             return SpacePage.builder().data(spaceInfo).meta(meta).build();
         }
     }

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -4,10 +4,10 @@ package org.layer.domain.space.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.layer.common.dto.Meta;
-import org.layer.common.exception.BaseCustomException;
 import org.layer.domain.space.dto.SpaceRequest;
 import org.layer.domain.space.dto.SpaceResponse;
 import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.exception.SpaceException;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
 import org.layer.domain.space.repository.SpaceRepository;
 import org.springframework.stereotype.Service;
@@ -52,12 +52,12 @@ public class SpaceService {
 
     @Transactional
     public void updateSpace(Long memberId, SpaceRequest.UpdateSpaceRequest updateSpaceRequest) {
-        spaceRepository.findByIdAndJoinedMemberId(updateSpaceRequest.id(), memberId).orElseThrow(() -> new BaseCustomException(SPACE_NOT_FOUND));
+        spaceRepository.findByIdAndJoinedMemberId(updateSpaceRequest.id(), memberId).orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
         spaceRepository.updateSpace(updateSpaceRequest.id(), updateSpaceRequest.category(), updateSpaceRequest.field(), updateSpaceRequest.name(), updateSpaceRequest.introduction());
     }
 
     public SpaceResponse.SpaceWithMemberCountInfo getSpaceById(Long memberId, Long spaceId) {
-        var foundSpace = spaceRepository.findByIdAndJoinedMemberId(spaceId, memberId).orElseThrow(() -> new BaseCustomException(SPACE_NOT_FOUND));
+        var foundSpace = spaceRepository.findByIdAndJoinedMemberId(spaceId, memberId).orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
 
         return SpaceResponse.SpaceWithMemberCountInfo.toResponse(foundSpace);
     }

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -3,7 +3,6 @@ package org.layer.domain.space.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.layer.common.dto.Meta;
 import org.layer.common.exception.BaseCustomException;
 import org.layer.domain.space.dto.SpaceRequest;
@@ -37,7 +36,7 @@ public class SpaceService {
         Long newCursor = !hasNextPage ? null : spacePages.isEmpty() ? null : spacePages.get(spacePages.size() - 1).getId();
 
 
-        var spaceList = spacePages.stream().map(SpaceResponse.SpaceWithUserCountInfo::toResponse).collect(Collectors.toList());
+        var spaceList = spacePages.stream().map(SpaceResponse.SpaceWithMemberCountInfo::toResponse).collect(Collectors.toList());
 
         var meta = Meta.builder().cursor(newCursor).hasNextPage(hasNextPage).build();
         return SpaceResponse.SpacePage.toResponse(spaceList, meta);
@@ -57,10 +56,10 @@ public class SpaceService {
         spaceRepository.updateSpace(updateSpaceRequest.id(), updateSpaceRequest.category(), updateSpaceRequest.field(), updateSpaceRequest.name(), updateSpaceRequest.introduction());
     }
 
-    public SpaceResponse.SpaceWithUserCountInfo getSpaceById(Long memberId, Long spaceId) {
+    public SpaceResponse.SpaceWithMemberCountInfo getSpaceById(Long memberId, Long spaceId) {
         var foundSpace = spaceRepository.findByIdAndJoinedMemberId(spaceId, memberId).orElseThrow(() -> new BaseCustomException(SPACE_NOT_FOUND));
 
-        return SpaceResponse.SpaceWithUserCountInfo.toResponse(foundSpace);
+        return SpaceResponse.SpaceWithMemberCountInfo.toResponse(foundSpace);
     }
 
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithMemberCount.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithMemberCount.java
@@ -27,10 +27,10 @@ public class SpaceWithMemberCount {
     @NotNull
     private Long leaderId;
     private Long formId;
-    private Long userCount;
+    private Long memberCount;
 
     @QueryProjection
-    public SpaceWithMemberCount(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, SpaceCategory category, SpaceField field, String name, String introduction, Long leaderId, Long formId, Long userCount) {
+    public SpaceWithMemberCount(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, SpaceCategory category, SpaceField field, String name, String introduction, Long leaderId, Long formId, Long memberCount) {
         this.id = id;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -40,6 +40,6 @@ public class SpaceWithMemberCount {
         this.introduction = introduction;
         this.leaderId = leaderId;
         this.formId = formId;
-        this.userCount = userCount;
+        this.memberCount = memberCount;
     }
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
@@ -48,7 +48,6 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
         var foundSpace = getSpaceWithMemberCountQuery()
                 .where(space.id.eq(spaceId)
                         .and(memberSpaceRelation.memberId.eq(memberId)))
-                .limit(1)
                 .fetchOne();
 
         if (isSpaceWithMemberCountEmpty(foundSpace)) {

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
@@ -1,13 +1,13 @@
 package org.layer.domain.space.repository;
 
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.layer.domain.space.dto.QSpaceWithMemberCount;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
+import org.layer.domain.space.entity.QMemberSpaceRelation;
 import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.entity.SpaceField;
 import org.springframework.stereotype.Repository;
@@ -34,26 +34,7 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
                 .and(cursorId == null ? null : space.id.gt(cursorId))
                 .and(hasCategory(category));
 
-        return queryFactory.select(
-                        new QSpaceWithMemberCount(
-                                space.id,
-                                space.createdAt,
-                                space.updatedAt,
-                                space.category,
-                                space.field,
-                                space.name,
-                                space.introduction,
-                                space.leaderId,
-                                space.formId,
-                                ExpressionUtils.as(JPAExpressions.select(
-                                                        memberSpaceRelation.id.count()
-                                                )
-                                                .from(memberSpaceRelation)
-                                                .where(memberSpaceRelation.space.id.eq(space.id))
-                                        , "userCount")
-                        ))
-                .from(space)
-                .join(memberSpaceRelation).on(space.id.eq(memberSpaceRelation.space.id))
+        return getSpaceWithMemberCountQuery()
                 .where(predicate)
                 .groupBy(space.id)
                 .orderBy(space.id.asc())
@@ -63,27 +44,8 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
 
     @Override
     public Optional<SpaceWithMemberCount> findByIdAndJoinedMemberId(Long spaceId, Long memberId) {
-        var foundSpace = queryFactory.select(
-                        new QSpaceWithMemberCount(space.id,
-                                space.createdAt,
-                                space.updatedAt,
-                                space.category,
-                                space.field,
-                                space.name,
-                                space.introduction,
-                                space.leaderId,
-                                space.formId,
-                                ExpressionUtils.as(JPAExpressions.select(
-                                                        memberSpaceRelation.id.count()
-                                                )
-                                                .from(memberSpaceRelation)
-                                                .where(memberSpaceRelation.space.id.eq(space.id))
-                                        , "userCount")
-                        )
-                )
-                .from(memberSpaceRelation)
-                .join(space)
-                .on(space.id.eq(memberSpaceRelation.space.id))
+
+        var foundSpace = getSpaceWithMemberCountQuery()
                 .where(space.id.eq(spaceId)
                         .and(memberSpaceRelation.memberId.eq(memberId)))
                 .limit(1)
@@ -93,7 +55,7 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
             return Optional.empty();
         }
         // TODO: 커스텀 에러로 변경
-        return Optional.ofNullable(foundSpace);
+        return Optional.of(foundSpace);
     }
 
     @Override
@@ -109,15 +71,32 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
         return query.where(space.id.eq(spaceId)).execute();
     }
 
+    private JPAQuery<SpaceWithMemberCount> getSpaceWithMemberCountQuery() {
+        QMemberSpaceRelation memberCountRelationTable = new QMemberSpaceRelation("msr");
+        return queryFactory.select(
+                        new QSpaceWithMemberCount(
+                                space.id,
+                                space.createdAt,
+                                space.updatedAt,
+                                space.category,
+                                space.field,
+                                space.name,
+                                space.introduction,
+                                space.leaderId,
+                                space.formId,
+                                memberCountRelationTable.space.id.count().as("memberCount")
+                        ))
+                .from(space)
+                .leftJoin(memberSpaceRelation).on(space.id.eq(memberSpaceRelation.space.id))
+                .leftJoin(memberCountRelationTable).on(space.id.eq(memberCountRelationTable.space.id));
+    }
+
 
     private BooleanExpression hasCategory(Optional<SpaceCategory> category) {
-        if (category.isPresent()) {
-            return space.category.eq(category.get());
-        }
-        return null;
+        return category.map(space.category::eq).orElse(null);
     }
 
     private boolean isSpaceWithMemberCountEmpty(SpaceWithMemberCount space) {
-        return space.getId() == null && space.getName() == null && space.getUserCount() == 0;
+        return space.getId() == null && space.getName() == null && space.getMemberCount() == 0;
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
- Retrospect API의 회원 수 조회 기능을 Space API로 이전했어요.
- 기존 회원수 조회 API에서 잘못된 결과를 반환하고 있었어요.
- 성능 최적화가 필요한 부분을 최적화 했어요.
- 현재 `layer`의 사용자는 `Member`로 부르고 있기 때문에 `userCount`라는 명칭을 `memberCount`로 변경했어요.


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
```cURL
curl -X 'GET' \
  'http://api.layerapp.io/api/auth/oauth2/kakao?code=bIq7a17tSqQjKiOJivxwLXV8HY486xh1533tEpeRjwjgMwHTmEWWNAAAAAQKPCPoAAABkKzDGRbo6jj-qNQmaA' \
  -H 'accept: */*'
```

```json
{
  "data": [
    {
      "id": 7,
      "category": "TEAM",
      "field": "DESIGN",
      "name": "이름",
      "introduction": "string",
      "formId": null,
      "memberCount": 2
    },
    {
      "id": 8,
      "category": "INDIVIDUAL",
      "field": "DESIGN",
      "name": "string",
      "introduction": "string",
      "formId": null,
      "memberCount": 1
    }
  ],
  "meta": {
    "hasNextPage": true,
    "cursor": 8
  }
}
```

![스크린샷 2024-07-14 오전 3 17 29](https://github.com/user-attachments/assets/bb21526b-c02d-4a8b-b835-c239f95c06a1)


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/LS-23 -> develop
- closed #
