### PR TITLE
Feat/lS-25 : 스페이스 초대하기/떠나기 API

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/api/SpaceApi.java
+++ b/layer-api/src/main/java/org/layer/domain/space/api/SpaceApi.java
@@ -2,6 +2,7 @@ package org.layer.domain.space.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -49,7 +50,7 @@ public interface SpaceApi {
             )
     }
     )
-    void createSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.CreateSpaceRequest createSpaceRequest);
+    ResponseEntity<Void> createSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.CreateSpaceRequest createSpaceRequest);
 
     @Operation(summary = "스페이스 수정하기", method = "POST", description = """
             스페이스를 수정합니다. <br />
@@ -66,7 +67,7 @@ public interface SpaceApi {
             )
     }
     )
-    void updateSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.UpdateSpaceRequest updateSpaceRequest);
+    ResponseEntity<Void> updateSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.UpdateSpaceRequest updateSpaceRequest);
 
     @Operation(summary = "스페이스 단건 조회하기", method = "GET", description = """
             스페이스 아이디를 통해 하나의 스페이스를 조회합니다.
@@ -78,4 +79,93 @@ public interface SpaceApi {
             })
     })
     ResponseEntity<SpaceResponse.SpaceWithMemberCountInfo> getSpaceById(@MemberId Long memberId, @PathVariable Long spaceId);
+
+
+    @Operation(summary = "스페이스 입장하기", method = "POST", description = """
+            공유받은 링크를 통해 스페이스에 입장합니다.
+            category가 TEAM인 경우만 가능합니다.
+            회원이 아닐 경우 입장할 수 없습니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", content = {
+                    @Content(mediaType = "application/json", schema = @Schema)
+            }),
+            @ApiResponse(
+                    responseCode = "400",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "SPACE_ALREADY_JOINED",
+                                            description = "이미 참여중인 스페이스",
+                                            value = """
+                                                    {
+                                                       "name": "SPACE_ALREADY_JOINED",
+                                                       "message": "이미 가입한 스페이스에요."
+                                                     }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "SPACE_NOT_FOUND",
+                                            description = "존재하지 않는 스페이스",
+                                            value = """
+                                                    {
+                                                        "name": "SPACE_NOT_FOUND",
+                                                        "message": "스페이스를 찾을 수 없어요."
+                                                    }
+                                                    """
+                                    )
+
+
+                            }
+                    )
+
+            )
+    })
+    ResponseEntity<Void> createMemberSpace(@MemberId Long memberId, @PathVariable Long spaceId);
+
+    @Operation(summary = "스페이스 탈퇴하기", method = "POST", description = """
+            내가 속한 스페이스를 탈퇴합니다.
+            category가 TEAM인 경우만 가능합니다.
+            회원이 아닐 경우 입장할 수 없습니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", content = {
+                    @Content(mediaType = "application/json", schema = @Schema)
+            }),
+            @ApiResponse(
+                    responseCode = "400",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "SPACE_NOT_JOINED",
+                                            description = "참여중인 스페이스가 아닐경우.",
+                                            value = """
+                                                    {
+                                                       "name": "SPACE_NOT_JOINED",
+                                                       "message": "참여중인 스페이스가 아니에요."
+                                                     }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "SPACE_NOT_FOUND",
+                                            description = "존재하지 않는 스페이스",
+                                            value = """
+                                                    {
+                                                        "name": "SPACE_NOT_FOUND",
+                                                        "message": "스페이스를 찾을 수 없어요."
+                                                    }
+                                                    """
+                                    )
+
+
+                            }
+                    )
+
+            )
+    })
+    ResponseEntity<Void> removeMemberSpace(@MemberId Long memberId, @PathVariable Long spaceId);
 }

--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
@@ -30,21 +30,39 @@ public class SpaceController implements SpaceApi {
 
     @Override
     @PutMapping("")
-    public void createSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.CreateSpaceRequest createSpaceRequest) {
+    public ResponseEntity<Void> createSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.CreateSpaceRequest createSpaceRequest) {
         spaceService.createSpace(memberId, createSpaceRequest);
+        return ResponseEntity.ok().build();
     }
 
     @Override
     @PostMapping("")
     @ResponseStatus(HttpStatus.ACCEPTED)
-    public void updateSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.UpdateSpaceRequest updateSpaceRequest) {
+    public ResponseEntity<Void> updateSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.UpdateSpaceRequest updateSpaceRequest) {
         spaceService.updateSpace(memberId, updateSpaceRequest);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{spaceId}")
     public ResponseEntity<SpaceResponse.SpaceWithMemberCountInfo> getSpaceById(@MemberId Long memberId, @PathVariable Long spaceId) {
         var foundSpace = spaceService.getSpaceById(memberId, spaceId);
         return ResponseEntity.ok((foundSpace));
+    }
+
+    @Override
+    @PostMapping("/join")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ResponseEntity<Void> createMemberSpace(@MemberId Long memberId, @RequestParam Long spaceId) {
+        spaceService.createMemberSpace(memberId, spaceId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PostMapping("/leave")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ResponseEntity<Void> removeMemberSpace(@MemberId Long memberId, @RequestParam Long spaceId) {
+        spaceService.removeMemberSpace(memberId, spaceId);
+        return ResponseEntity.ok().build();
     }
 }
 

--- a/layer-api/src/main/java/org/layer/domain/space/exception/SpaceExceptionType.java
+++ b/layer-api/src/main/java/org/layer/domain/space/exception/SpaceExceptionType.java
@@ -9,11 +9,13 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @RequiredArgsConstructor
 public enum SpaceExceptionType implements ExceptionType {
 
-    /**
-     *
-     */
 
-    SPACE_NOT_FOUND(BAD_REQUEST, "스페이스를 찾을 수 없어요.");
+    SPACE_NOT_FOUND(BAD_REQUEST, "스페이스를 찾을 수 없어요."),
+
+    SPACE_NOT_JOINED(BAD_REQUEST, "참여중인 스페이스가 아니에요."),
+    SPACE_LEADER_CANNOT_LEAVE(BAD_REQUEST, "스페이스를 팀장은 떠날 수 없어요."),
+    SPACE_ALREADY_JOINED(BAD_REQUEST, "이미 가입한 스페이스에요.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -7,6 +7,7 @@ import org.layer.common.dto.Meta;
 import org.layer.domain.space.dto.SpaceRequest;
 import org.layer.domain.space.dto.SpaceResponse;
 import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.exception.SpaceException;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
 import org.layer.domain.space.repository.SpaceRepository;
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Collectors;
 
-import static org.layer.domain.space.exception.SpaceExceptionType.SPACE_NOT_FOUND;
+import static org.layer.domain.space.exception.SpaceExceptionType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -60,6 +61,78 @@ public class SpaceService {
         var foundSpace = spaceRepository.findByIdAndJoinedMemberId(spaceId, memberId).orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
 
         return SpaceResponse.SpaceWithMemberCountInfo.toResponse(foundSpace);
+    }
+
+    @Transactional
+    public void createMemberSpace(Long memberId, Long spaceId) {
+
+        /*
+          존재하는 스페이스 여부 확인
+         */
+        var foundSpace = spaceRepository.findById(spaceId)
+                .orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND)
+                );
+
+        if (foundSpace.getCategory() == SpaceCategory.INDIVIDUAL) {
+            throw new SpaceException(SPACE_NOT_FOUND);
+        }
+
+
+        /*
+          이미 참여중인 스페이스 여부 확인
+         */
+        memberSpaceRelationRepository.findBySpaceIdAndMemberId(spaceId, memberId).ifPresent(it -> {
+            throw new SpaceException(SPACE_ALREADY_JOINED);
+        });
+
+        /*
+          스페이스 참여여부 저장
+         */
+        var joinedSpace = MemberSpaceRelation.builder()
+                .space(foundSpace)
+                .memberId(memberId)
+                .build();
+        memberSpaceRelationRepository.save(joinedSpace);
+    }
+
+    @Transactional
+    public void removeMemberSpace(Long memberId, Long spaceId) {
+        /*
+          존재하는 스페이스 여부 확인
+         */
+        var foundSpace = spaceRepository.findById(spaceId)
+                .orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND)
+                );
+
+        /*
+          TODO: 유효성 검사가 이루어지는 레이어가 Service 계층이 맞을까?
+         */
+        if (memberId.equals(foundSpace.getLeaderId())) {
+            throw new SpaceException(SPACE_LEADER_CANNOT_LEAVE);
+        }
+        /*
+          개인 스페이스의 경우, 이탈 시 Space 엔티티의 로직이 된다.
+          따라서 INDIVIDUAL인 Space인 경우 가능한 케이스는 2가지로
+          1. Space 삭제
+          2. 속한 스페이스 떠나기, 스페이스 삭제하기 분리
+          현재는 2번 케이스를 기준으로 구현되어 있음
+         */
+        if (foundSpace.getCategory() == SpaceCategory.INDIVIDUAL) {
+            throw new SpaceException(SPACE_NOT_FOUND);
+        }
+
+        /*
+          이미 참여중인 스페이스 여부 확인
+         */
+        var foundMemberSpaceRelation = memberSpaceRelationRepository.findBySpaceIdAndMemberId(spaceId, memberId)
+                .orElseThrow(
+                        () -> new SpaceException(SPACE_ALREADY_JOINED)
+                );
+
+        /*
+          스페이스 참여여부 삭제 ( 스페이스 떠나기 )
+         */
+        memberSpaceRelationRepository.deleteById(foundMemberSpaceRelation.getId());
     }
 
 }

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -105,11 +105,11 @@ public class SpaceService {
                 );
 
         /*
-          TODO: 유효성 검사가 이루어지는 레이어가 Service 계층이 맞을까?
+          스페이스 팀장 여부 확인
          */
-        if (memberId.equals(foundSpace.getLeaderId())) {
-            throw new SpaceException(SPACE_LEADER_CANNOT_LEAVE);
-        }
+        foundSpace.isLeaderSpace(memberId)
+                .orElseThrow(() -> new SpaceException(SPACE_LEADER_CANNOT_LEAVE));
+
         /*
           개인 스페이스의 경우, 이탈 시 Space 엔티티의 로직이 된다.
           따라서 INDIVIDUAL인 Space인 경우 가능한 케이스는 2가지로

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
@@ -6,6 +6,8 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.layer.domain.BaseEntity;
 
+import java.util.Optional;
+
 @Getter
 @Entity
 @AllArgsConstructor
@@ -32,4 +34,11 @@ public class Space extends BaseEntity {
      * Form Relationid
      */
     private Long formId;
+
+    public Optional<Boolean> isLeaderSpace(Long memberId) {
+        if (leaderId.equals(memberId)) {
+            return Optional.empty();
+        }
+        return Optional.of(true);
+    }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [x] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
- 스페이스 초대 링크를 통해 페이지에 진입 시 호출할 API를 추가했어요.
  - 명칭을 `초대하기` 라고 하였지만 사실 `입장하기` 가 더 맞는 표현인 것 같아요
- 내가 속한 스페이스 떠나기 API를 추가했어요.


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
`스페이스 떠나기`  관련하여 논의가 필요하다 판단된 부분에 주석 달아뒀어요!
해당 주석 내용 공유드립니다.
```
개인 스페이스의 경우, 이탈 시 Space 엔티티의 로직이 된다.
따라서 INDIVIDUAL인 Space인 경우 가능한 케이스는 2가지로
1. Space 삭제
2. 속한 스페이스 떠나기, 스페이스 삭제하기 분리
현재는 2번 케이스를 기준으로 구현되어 있음
```



## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
### 스페이스 입장하기 API
<img width="1046" alt="스크린샷 2024-07-14 오후 4 13 27" src="https://github.com/user-attachments/assets/72fd1ffe-27a4-4e94-bb50-dd29a603c4d8">

<img width="1044" alt="스크린샷 2024-07-14 오후 4 13 21" src="https://github.com/user-attachments/assets/a022445a-99ed-4b1e-a0f2-bde2866e2991">
<img width="1046" alt="스크린샷 2024-07-14 오후 4 12 53" src="https://github.com/user-attachments/assets/9ac42aa7-b449-4995-91e9-1bba3df0a8ab">

### 스페이스 떠나기 API

<img width="1046" alt="스크린샷 2024-07-14 오후 4 14 31" src="https://github.com/user-attachments/assets/7255098e-cbfc-41da-b1bf-fbf3a22c7535">
<img width="1049" alt="스크린샷 2024-07-14 오후 4 13 50" src="https://github.com/user-attachments/assets/a2087b3c-36fa-4670-906d-201fad71c3ac">


## 👉 반영 브랜치


<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/LS-25 -> develop
- closed #
