### PR TITLE
feat/LS-24: 특정 회고 질문 목록 조회 구현

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/question/controller/QuestionApi.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/QuestionApi.java
@@ -1,0 +1,16 @@
+package org.layer.domain.question.controller;
+
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.question.controller.dto.response.QuestionListGetResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "질문", description = "질문 관련 API")
+public interface QuestionApi {
+	@Operation(summary = "특정 회고 질문 목록 조회", description = "")
+	ResponseEntity<QuestionListGetResponse> getRetrospectQuestions(@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId, @MemberId Long memberId);
+}

--- a/layer-api/src/main/java/org/layer/domain/question/controller/QuestionController.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/QuestionController.java
@@ -30,7 +30,7 @@ public class QuestionController implements QuestionApi{
 		List<QuestionGetResponse> responses = questionService.getRetrospectQuestions(spaceId, retrospectId, memberId)
 			.questions()
 			.stream()
-			.map(q -> QuestionGetResponse.of(q.question(), q.order()))
+			.map(q -> QuestionGetResponse.of(q.question(), q.order(), q.questionType()))
 			.toList();
 
 		return ResponseEntity.ok().body(QuestionListGetResponse.of(responses));

--- a/layer-api/src/main/java/org/layer/domain/question/controller/QuestionController.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/QuestionController.java
@@ -1,0 +1,38 @@
+package org.layer.domain.question.controller;
+
+import java.util.List;
+
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.question.controller.dto.response.QuestionGetResponse;
+import org.layer.domain.question.controller.dto.response.QuestionListGetResponse;
+import org.layer.domain.question.service.QuestionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/space/{spaceId}/retrospect/{retrospectId}/question")
+public class QuestionController implements QuestionApi{
+	private final QuestionService questionService;
+
+	@Override
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<QuestionListGetResponse> getRetrospectQuestions(@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId, @MemberId Long memberId) {
+
+		List<QuestionGetResponse> responses = questionService.getRetrospectQuestions(spaceId, retrospectId, memberId)
+			.questions()
+			.stream()
+			.map(q -> QuestionGetResponse.of(q.question(), q.order()))
+			.toList();
+
+		return ResponseEntity.ok().body(QuestionListGetResponse.of(responses));
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionGetResponse.java
@@ -3,9 +3,10 @@ package org.layer.domain.question.controller.dto.response;
 
 public record QuestionGetResponse(
 	String question,
-	int order
+	int order,
+	String questionType
 ) {
-	public static QuestionGetResponse of(String question, int order) {
-		return new QuestionGetResponse(question, order);
+	public static QuestionGetResponse of(String question, int order, String questionType) {
+		return new QuestionGetResponse(question, order, questionType);
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionGetResponse.java
@@ -1,0 +1,11 @@
+package org.layer.domain.question.controller.dto.response;
+
+
+public record QuestionGetResponse(
+	String question,
+	int order
+) {
+	public static QuestionGetResponse of(String question, int order) {
+		return new QuestionGetResponse(question, order);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionListGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionListGetResponse.java
@@ -1,0 +1,11 @@
+package org.layer.domain.question.controller.dto.response;
+
+import java.util.List;
+
+public record QuestionListGetResponse(
+	List<QuestionGetResponse> questions
+) {
+	public static QuestionListGetResponse of(List<QuestionGetResponse> questions){
+		return new QuestionListGetResponse(questions);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
@@ -1,0 +1,53 @@
+package org.layer.domain.question.service;
+
+import static org.layer.common.exception.MemberSpaceRelationExceptionType.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.layer.domain.question.entity.Question;
+import org.layer.domain.question.enums.QuestionOwner;
+import org.layer.domain.question.repository.QuestionRepository;
+import org.layer.domain.question.service.dto.response.QuestionGetServiceResponse;
+import org.layer.domain.question.service.dto.response.QuestionListGetServiceResponse;
+import org.layer.domain.retrospect.entity.Retrospect;
+import org.layer.domain.retrospect.repository.RetrospectRepository;
+import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.exception.MemberSpaceRelationException;
+import org.layer.domain.space.repository.MemberSpaceRelationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionService {
+	private final QuestionRepository questionRepository;
+	private final MemberSpaceRelationRepository memberSpaceRelationRepository;
+	private final RetrospectRepository retrospectRepository;
+
+	public QuestionListGetServiceResponse getRetrospectQuestions(Long spaceId, Long retrospectId, Long memberId){
+
+		// 해당 멤버가 스페이스 소속인지 검증 로직
+		Optional<MemberSpaceRelation> team = memberSpaceRelationRepository.findBySpaceIdAndMemberId(
+			spaceId, memberId);
+		if(team.isEmpty()){
+			throw new MemberSpaceRelationException(NOT_FOUND_MEMBER_SPACE_RELATION);
+		}
+
+		// 해당 회고가 있는지, PROCEEDING 상태인지 검증
+		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
+		retrospect.isProceedingRetrospect();
+
+		List<Question> questions = questionRepository.findAllByQuestionOwnerIdAndQuestionOwnerOrderByQuestionOrder(
+			retrospectId, QuestionOwner.TEAM);
+
+		List<QuestionGetServiceResponse> serviceResponses = questions.stream()
+			.map(q -> QuestionGetServiceResponse.of(q.getContent(), q.getQuestionOrder()))
+			.toList();
+
+		return QuestionListGetServiceResponse.of(serviceResponses);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
@@ -45,7 +45,7 @@ public class QuestionService {
 			retrospectId, QuestionOwner.TEAM);
 
 		List<QuestionGetServiceResponse> serviceResponses = questions.stream()
-			.map(q -> QuestionGetServiceResponse.of(q.getContent(), q.getQuestionOrder()))
+			.map(q -> QuestionGetServiceResponse.of(q.getContent(), q.getQuestionOrder(), q.getQuestionType().getStyle()))
 			.toList();
 
 		return QuestionListGetServiceResponse.of(serviceResponses);

--- a/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionGetServiceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionGetServiceResponse.java
@@ -2,9 +2,10 @@ package org.layer.domain.question.service.dto.response;
 
 public record QuestionGetServiceResponse(
 	String question,
-	int order
+	int order,
+	String questionType
 ) {
-	public static QuestionGetServiceResponse of(String question, int order) {
-		return new QuestionGetServiceResponse(question, order);
+	public static QuestionGetServiceResponse of(String question, int order, String questionType) {
+		return new QuestionGetServiceResponse(question, order, questionType);
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionGetServiceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionGetServiceResponse.java
@@ -1,0 +1,10 @@
+package org.layer.domain.question.service.dto.response;
+
+public record QuestionGetServiceResponse(
+	String question,
+	int order
+) {
+	public static QuestionGetServiceResponse of(String question, int order) {
+		return new QuestionGetServiceResponse(question, order);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionListGetServiceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionListGetServiceResponse.java
@@ -1,0 +1,11 @@
+package org.layer.domain.question.service.dto.response;
+
+import java.util.List;
+
+public record QuestionListGetServiceResponse(
+	List<QuestionGetServiceResponse> questions
+) {
+	public static QuestionListGetServiceResponse of(List<QuestionGetServiceResponse> questions){
+		return new QuestionListGetServiceResponse(questions);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -4,6 +4,7 @@ import static org.layer.common.exception.MemberSpaceRelationExceptionType.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.layer.domain.answer.entity.Answers;
 import org.layer.domain.answer.repository.AnswerRepository;
@@ -46,8 +47,9 @@ public class RetrospectService {
 		Retrospect retrospect = getRetrospect(request);
 		Retrospect savedRetrospect = retrospectRepository.save(retrospect);
 
+		AtomicInteger teamIndex = new AtomicInteger(1);
 		List<Question> questions = request.questions().stream()
-			.map(q -> new Question(savedRetrospect.getId(), q, QuestionOwner.TEAM, QuestionType.PLAIN_TEXT))
+			.map(q -> new Question(savedRetrospect.getId(), q, teamIndex.getAndIncrement(), QuestionOwner.TEAM, QuestionType.PLAIN_TEXT))
 			.toList();
 		questionRepository.saveAll(questions);
 
@@ -55,8 +57,9 @@ public class RetrospectService {
 		Form form = new Form(memberId, request.title(), request.introduction());
 		Form savedForm = formRepository.save(form);
 
+		AtomicInteger myIndex = new AtomicInteger(1);
 		List<Question> myQuestions = request.questions().stream()
-			.map(q -> new Question(savedForm.getId(), q, QuestionOwner.INDIVIDUAL, QuestionType.PLAIN_TEXT))
+			.map(q -> new Question(savedForm.getId(), q, myIndex.getAndIncrement(), QuestionOwner.INDIVIDUAL, QuestionType.PLAIN_TEXT))
 			.toList();
 		questionRepository.saveAll(myQuestions);
 	}

--- a/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
@@ -1,0 +1,25 @@
+package org.layer.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RetrospectExceptionType implements ExceptionType{
+	NOT_PROCEEDING_RETROSPECT(HttpStatus.BAD_REQUEST, "진행중인 회고가 아닙니다."),
+	NOT_FOUND_RETROSPECT(HttpStatus.NOT_FOUND, "유효한 회고가 존재하지 않습니다.");
+
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus httpStatus() {
+		return status;
+	}
+
+	@Override
+	public String message() {
+		return message;
+	}
+}

--- a/layer-domain/src/main/java/org/layer/domain/question/entity/Question.java
+++ b/layer-domain/src/main/java/org/layer/domain/question/entity/Question.java
@@ -19,11 +19,16 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseEntity {
 
+    /*
+        questionOwnerId은 retrospectId or memberId 중 하나이다.
+    */
     @NotNull
     private Long questionOwnerId;
 
     @NotNull
     private String content;
+
+    private int questionOrder;
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -31,15 +36,16 @@ public class Question extends BaseEntity {
 
     @Column(length = 20)
     @NotNull
-    @Convert(converter = QuestionTypeConverter.class)
+    @Enumerated(EnumType.STRING)
     private QuestionType questionType;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<QuestionOption> options = new HashSet<>();
 
-    public Question(Long questionOwnerId, String content, QuestionOwner questionOwner, QuestionType questionType) {
+    public Question(Long questionOwnerId, String content, int questionOrder, QuestionOwner questionOwner, QuestionType questionType) {
         this.questionOwnerId = questionOwnerId;
         this.content = content;
+        this.questionOrder = questionOrder;
         this.questionOwner = questionOwner;
         this.questionType = questionType;
     }

--- a/layer-domain/src/main/java/org/layer/domain/question/repository/QuestionRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/question/repository/QuestionRepository.java
@@ -1,8 +1,11 @@
 package org.layer.domain.question.repository;
 
+import java.util.List;
+
 import org.layer.domain.question.entity.Question;
+import org.layer.domain.question.enums.QuestionOwner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-
+	List<Question> findAllByQuestionOwnerIdAndQuestionOwnerOrderByQuestionOrder(Long questionOwnerId, QuestionOwner questionOwner);
 }

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -1,6 +1,9 @@
 package org.layer.domain.retrospect.entity;
 
+import static org.layer.common.exception.RetrospectExceptionType.*;
+
 import org.layer.domain.common.BaseTimeEntity;
+import org.layer.domain.retrospect.exception.RetrospectException;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -41,5 +44,11 @@ public class Retrospect extends BaseTimeEntity {
         this.title = title;
         this.introduction = introduction;
         this.retrospectStatus = retrospectStatus;
+    }
+
+    public void isProceedingRetrospect(){
+        if(!this.retrospectStatus.equals(RetrospectStatus.PROCEEDING)){
+            throw new RetrospectException(NOT_PROCEEDING_RETROSPECT);
+        }
     }
 }

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/exception/RetrospectException.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/exception/RetrospectException.java
@@ -1,0 +1,10 @@
+package org.layer.domain.retrospect.exception;
+
+import org.layer.common.exception.BaseCustomException;
+import org.layer.common.exception.ExceptionType;
+
+public class RetrospectException extends BaseCustomException {
+	public RetrospectException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/repository/RetrospectRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/repository/RetrospectRepository.java
@@ -1,10 +1,18 @@
 package org.layer.domain.retrospect.repository;
 
+import static org.layer.common.exception.RetrospectExceptionType.*;
+
 import java.util.List;
 
 import org.layer.domain.retrospect.entity.Retrospect;
+import org.layer.domain.retrospect.exception.RetrospectException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 	List<Retrospect> findAllBySpaceId(Long spaceId);
+
+	default Retrospect findByIdOrThrow(Long retrospectId){
+		return findById(retrospectId)
+			.orElseThrow(() -> new RetrospectException(NOT_FOUND_RETROSPECT));
+	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 엔티티 변경이 있었습니다. 커밋보고 의견주시면 감사하겠습니다!
- 그 외는 특이사항 없었습니다!

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="868" alt="스크린샷 2024-07-14 오후 9 12 32" src="https://github.com/user-attachments/assets/7e2d6d87-018f-4fdf-aa14-c3b31f77cff4">


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#LS-24
- closed #
