### PR TITLE
feat/LS-33: 이미지 업로드 API 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,11 @@ project(":layer-external") {
         implementation project(path: ':layer-common')
         implementation project(path: ':layer-domain')
 
+        // NCP Object Storage
+        implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
         testImplementation platform('org.junit:junit-bom:5.9.1')
         testImplementation 'org.junit.jupiter:junit-jupiter'
+
     }
 }

--- a/layer-api/src/main/java/org/layer/LayerApplication.java
+++ b/layer-api/src/main/java/org/layer/LayerApplication.java
@@ -7,7 +7,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@OpenAPIDefinition(servers = {@Server(url = "https://api.layerapp.io", description = "운영서버")})
+@OpenAPIDefinition(servers = {
+        @Server(url = "https://api.layerapp.io", description = "운영서버"),
+        @Server(url = "http://localhost:8080", description = "개발서버")})
 @SpringBootApplication
 @EnableJpaAuditing
 public class LayerApplication {

--- a/layer-api/src/main/java/org/layer/config/SecurityConfig.java
+++ b/layer-api/src/main/java/org/layer/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                                 .requestMatchers(new AntPathRequestMatcher("/api/test")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/auth/test")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/h2-console/**")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/external/image/presigned")).permitAll()
                                 .anyRequest().authenticated()
                 )
                 .headers(headers -> headers

--- a/layer-api/src/main/java/org/layer/domain/external/api/ExternalApi.java
+++ b/layer-api/src/main/java/org/layer/domain/external/api/ExternalApi.java
@@ -1,0 +1,33 @@
+package org.layer.domain.external.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.external.dto.ExternalRequest;
+import org.layer.domain.external.dto.ExternalResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "외부 API")
+public interface ExternalApi {
+    @Operation(summary = "Presigned URL 발급받기",
+            method = "POST", description = """
+            이미지 업로드를 위한 Presigned URL 발급합니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200",
+                    content = {
+                            @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ExternalResponse.GetPreSignedURLResponse.class)
+                            )
+                    }
+            )
+    })
+    ResponseEntity<ExternalResponse.GetPreSignedURLResponse> getPresignedURL(@MemberId Long memberId, ExternalRequest.GetPreSignedURLRequest getPreSignedURLRequest);
+
+}

--- a/layer-api/src/main/java/org/layer/domain/external/controller/ExternalController.java
+++ b/layer-api/src/main/java/org/layer/domain/external/controller/ExternalController.java
@@ -1,6 +1,7 @@
 package org.layer.domain.external.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.layer.common.annotation.MemberId;
 import org.layer.domain.external.api.ExternalApi;
 import org.layer.domain.external.dto.ExternalRequest;
 import org.layer.domain.external.dto.ExternalResponse;
@@ -21,7 +22,7 @@ public class ExternalController implements ExternalApi {
     @Override
     @GetMapping("/image/presigned")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ExternalResponse.GetPreSignedURLResponse> getPresignedURL(Long memberId, ExternalRequest.GetPreSignedURLRequest getPreSignedURLRequest) {
+    public ResponseEntity<ExternalResponse.GetPreSignedURLResponse> getPresignedURL(@MemberId Long memberId, ExternalRequest.GetPreSignedURLRequest getPreSignedURLRequest) {
         String url = ncpService.getPreSignedUrl(memberId, getPreSignedURLRequest.domain());
 
         return ResponseEntity.ok(ExternalResponse.GetPreSignedURLResponse.toResponse(url));

--- a/layer-api/src/main/java/org/layer/domain/external/controller/ExternalController.java
+++ b/layer-api/src/main/java/org/layer/domain/external/controller/ExternalController.java
@@ -1,0 +1,29 @@
+package org.layer.domain.external.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.layer.domain.external.api.ExternalApi;
+import org.layer.domain.external.dto.ExternalRequest;
+import org.layer.domain.external.dto.ExternalResponse;
+import org.layer.external.ncp.service.NcpService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/external")
+public class ExternalController implements ExternalApi {
+
+    private final NcpService ncpService;
+
+    @Override
+    @GetMapping("/image/presigned")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ExternalResponse.GetPreSignedURLResponse> getPresignedURL(Long memberId, ExternalRequest.GetPreSignedURLRequest getPreSignedURLRequest) {
+        String url = ncpService.getPreSignedUrl(memberId, getPreSignedURLRequest.domain());
+
+        return ResponseEntity.ok(ExternalResponse.GetPreSignedURLResponse.toResponse(url));
+    }
+}

--- a/layer-api/src/main/java/org/layer/domain/external/dto/ExternalRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/external/dto/ExternalRequest.java
@@ -1,0 +1,14 @@
+package org.layer.domain.external.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.layer.external.ncp.enums.ImageDomain;
+
+public class ExternalRequest {
+
+    @Schema(description = "Presigned URL 발급받기")
+    public record GetPreSignedURLRequest(
+            @Schema(description = "발급받을 이미지의 활용 도메인")
+            ImageDomain domain
+    ) {
+    }
+}

--- a/layer-api/src/main/java/org/layer/domain/external/dto/ExternalResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/external/dto/ExternalResponse.java
@@ -1,0 +1,25 @@
+package org.layer.domain.external.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import org.layer.external.ncp.exception.ExternalExeption;
+
+import java.util.Optional;
+
+import static org.layer.common.exception.ExternalExceptionType.INTERNAL_SERVER_ERROR;
+
+public class ExternalResponse {
+
+    @Builder
+    @Schema(description = "Presigned URL 응답")
+    public record GetPreSignedURLResponse(
+            @Schema(description = "생성된 Presigned URL")
+            @NotNull
+            String url
+    ) {
+        public static GetPreSignedURLResponse toResponse(String url) {
+            return Optional.ofNullable(url).map(it -> GetPreSignedURLResponse.builder().url(url).build()).orElseThrow(() -> new ExternalExeption(INTERNAL_SERVER_ERROR));
+        }
+    }
+}

--- a/layer-api/src/main/java/org/layer/domain/space/api/SpaceApi.java
+++ b/layer-api/src/main/java/org/layer/domain/space/api/SpaceApi.java
@@ -35,7 +35,7 @@ public interface SpaceApi {
     )
     ResponseEntity<SpaceResponse.SpacePage> getMySpaceList(@MemberId Long memberId, @ModelAttribute @Validated SpaceRequest.GetSpaceRequest getSpaceRequest);
 
-    @Operation(summary = "스페이스 생성하기", method = "PUT", description = """
+    @Operation(summary = "스페이스 생성하기", method = "POST", description = """
             스페이스를 생성합니다. <br />
             생성 성공 시 아무것도 반환하지 않습니다.
             """)
@@ -52,7 +52,7 @@ public interface SpaceApi {
     )
     ResponseEntity<Void> createSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.CreateSpaceRequest createSpaceRequest);
 
-    @Operation(summary = "스페이스 수정하기", method = "POST", description = """
+    @Operation(summary = "스페이스 수정하기", method = "PUT", description = """
             스페이스를 수정합니다. <br />
             생성 성공 시 아무것도 반환하지 않습니다.
             """)

--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
@@ -29,14 +29,14 @@ public class SpaceController implements SpaceApi {
     }
 
     @Override
-    @PutMapping("")
+    @PostMapping("")
     public ResponseEntity<Void> createSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.CreateSpaceRequest createSpaceRequest) {
         spaceService.createSpace(memberId, createSpaceRequest);
         return ResponseEntity.ok().build();
     }
 
     @Override
-    @PostMapping("")
+    @PutMapping("")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> updateSpace(@MemberId Long memberId, @RequestBody @Validated SpaceRequest.UpdateSpaceRequest updateSpaceRequest) {
         spaceService.updateSpace(memberId, updateSpaceRequest);

--- a/layer-api/src/main/java/org/layer/domain/space/dto/SpaceRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/space/dto/SpaceRequest.java
@@ -16,6 +16,9 @@ public class SpaceRequest {
 
     @Schema(description = "스페이스 생성하기")
     public record CreateSpaceRequest(
+
+            @Schema(description = "스페이스 이미지 주소")
+            String bannerUrl,
             @Schema(description = "프로젝트 유형 카테고리", example = "INDIVIDUAL")
             @NotNull
             SpaceCategory category,
@@ -36,6 +39,7 @@ public class SpaceRequest {
                     .name(name)
                     .introduction(introduction)
                     .leaderId(memberId)
+                    .bannerUrl(bannerUrl)
                     .build();
         }
     }
@@ -43,6 +47,8 @@ public class SpaceRequest {
     @AtLeastNotNull(min = 2)
     @Schema(description = "스페이스 수정하기")
     public record UpdateSpaceRequest(
+            @Schema(description = "수정하고자 하는 배너 주소")
+            String bannerUrl,
 
             @Schema(description = "수정하고자 하는 스페이스 아이디")
             @NotNull
@@ -69,6 +75,7 @@ public class SpaceRequest {
                     .name(name)
                     .introduction(introduction)
                     .leaderId(memberId)
+                    .bannerUrl(bannerUrl)
                     .build();
         }
     }

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -54,7 +54,7 @@ public class SpaceService {
     @Transactional
     public void updateSpace(Long memberId, SpaceRequest.UpdateSpaceRequest updateSpaceRequest) {
         spaceRepository.findByIdAndJoinedMemberId(updateSpaceRequest.id(), memberId).orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
-        spaceRepository.updateSpace(updateSpaceRequest.id(), updateSpaceRequest.category(), updateSpaceRequest.field(), updateSpaceRequest.name(), updateSpaceRequest.introduction());
+        spaceRepository.updateSpace(updateSpaceRequest.id(), updateSpaceRequest.category(), updateSpaceRequest.field(), updateSpaceRequest.name(), updateSpaceRequest.introduction(), updateSpaceRequest.bannerUrl());
     }
 
     public SpaceResponse.SpaceWithMemberCountInfo getSpaceById(Long memberId, Long spaceId) {

--- a/layer-common/src/main/java/org/layer/common/exception/ExternalExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/ExternalExceptionType.java
@@ -1,0 +1,22 @@
+package org.layer.common.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ExternalExceptionType implements ExceptionType {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알수 없는 에러에요.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return null;
+    }
+
+    @Override
+    public String message() {
+        return null;
+    }
+}

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Space extends BaseEntity {
 
+    private String bannerUrl;
+
     @NotNull
     @Enumerated(EnumType.STRING)
     private SpaceCategory category;

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
@@ -19,6 +19,6 @@ public interface SpaceCustomRepository {
 
     Optional<SpaceWithMemberCount> findByIdAndJoinedMemberId(Long spaceId, Long memberId);
 
-    public Long updateSpace(Long spaceId, SpaceCategory category, SpaceField field, String name, String introduction, String bannerUrl);
+    Long updateSpace(Long spaceId, SpaceCategory category, SpaceField field, String name, String introduction, String bannerUrl);
 
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
@@ -19,6 +19,6 @@ public interface SpaceCustomRepository {
 
     Optional<SpaceWithMemberCount> findByIdAndJoinedMemberId(Long spaceId, Long memberId);
 
-    public Long updateSpace(Long spaceId, SpaceCategory category, SpaceField field, String name, String introduction);
+    public Long updateSpace(Long spaceId, SpaceCategory category, SpaceField field, String name, String introduction, String bannerUrl);
 
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
@@ -58,7 +58,7 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
     }
 
     @Override
-    public Long updateSpace(Long spaceId, SpaceCategory category, SpaceField field, String name, String introduction) {
+    public Long updateSpace(Long spaceId, SpaceCategory category, SpaceField field, String name, String introduction, String bannerUrl) {
         var query = queryFactory.update(space);
 
         // null 값 제거
@@ -66,6 +66,7 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
         Optional.ofNullable(field).ifPresent(it -> query.set(space.field, it));
         Optional.ofNullable(name).ifPresent(it -> query.set(space.name, it));
         Optional.ofNullable(introduction).ifPresent(it -> query.set(space.introduction, it));
+        Optional.ofNullable(bannerUrl).ifPresent(it -> query.set(space.bannerUrl, it));
 
         return query.where(space.id.eq(spaceId)).execute();
     }

--- a/layer-external/src/main/java/org/layer/external/ncp/config/NcpConfig.java
+++ b/layer-external/src/main/java/org/layer/external/ncp/config/NcpConfig.java
@@ -1,0 +1,37 @@
+package org.layer.external.ncp.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NcpConfig {
+    @Value("${ncp.storage.accessKey}")
+    private String accessKey;
+
+    @Value("${ncp.storage.secretKey}")
+    private String secretKey;
+
+    @Value("${ncp.storage.region}")
+    private String region;
+
+    @Value("${ncp.storage.endpoint}")
+    private String endPoint;
+
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,
+                secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint,
+                        region))
+                .build();
+    }
+}

--- a/layer-external/src/main/java/org/layer/external/ncp/enums/ImageDomain.java
+++ b/layer-external/src/main/java/org/layer/external/ncp/enums/ImageDomain.java
@@ -1,0 +1,5 @@
+package org.layer.external.ncp.enums;
+
+public enum ImageDomain {
+    SPACE,
+}

--- a/layer-external/src/main/java/org/layer/external/ncp/exception/ExternalExeption.java
+++ b/layer-external/src/main/java/org/layer/external/ncp/exception/ExternalExeption.java
@@ -1,0 +1,10 @@
+package org.layer.external.ncp.exception;
+
+import org.layer.common.exception.BaseCustomException;
+import org.layer.common.exception.ExceptionType;
+
+public class ExternalExeption extends BaseCustomException {
+    public ExternalExeption(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/layer-external/src/main/java/org/layer/external/ncp/service/NcpService.java
+++ b/layer-external/src/main/java/org/layer/external/ncp/service/NcpService.java
@@ -1,0 +1,53 @@
+package org.layer.external.ncp.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.layer.external.ncp.enums.ImageDomain;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NcpService {
+
+    @Value("${ncp.storage.bucketName}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    public String getPreSignedUrl(Long memberId, ImageDomain imageDomain) {
+        String fileName = imageDomain + "/" + memberId.toString() + "/" + UUID.randomUUID();
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(bucket, fileName);
+
+        return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String bucket, String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName)
+                        .withMethod(HttpMethod.PUT)
+                        .withExpiration(getPreSignedUrlExpiration());
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL,
+                CannedAccessControlList.PublicRead.toString());
+        return generatePresignedUrlRequest;
+    }
+
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 2;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [ ] docs 작업, swagger 작업
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
- pre-signed-url 기반 이미지 업로드 기능을 구현했어요.
- S3 SDK를 통해 ncp bucket과 연동했어요


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- ncp 연결을 위한 환경변수가 추가됬어요. 수정부분 포함 노션에 최신화 완료했습니다


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
- 이미지 업로드 url 요청 결과
![image](https://github.com/user-attachments/assets/8d382ff9-848d-4e22-b275-b594a74d4b2c)
### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/LS-33 -> develop
- closed #
