### PR TITLE
chore/LS-35 : 여러 API 뷰에 맞게 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/LayerApplication.java
+++ b/layer-api/src/main/java/org/layer/LayerApplication.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @OpenAPIDefinition(servers = {
@@ -12,6 +13,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
         @Server(url = "http://localhost:8080", description = "개발서버")})
 @SpringBootApplication
 @EnableJpaAuditing
+@ComponentScan(basePackages = {"org.layer.domain.common"})
 public class LayerApplication {
     public static void main(String[] args) {
         SpringApplication.run(LayerApplication.class, args);

--- a/layer-api/src/main/java/org/layer/domain/answer/controller/dto/request/AnswerCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/controller/dto/request/AnswerCreateRequest.java
@@ -1,8 +1,14 @@
 package org.layer.domain.answer.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "AnswerCreateRequest", description = "회고 작성 요청 Dto")
 public record AnswerCreateRequest(
+	@Schema(description = "질문 id", example = "1")
 	Long questionId,
+	@Schema(description = "질문 타입", example = "plain_text")
 	String questionType,
+	@Schema(description = "질문에 대한 답변", example = "깊은 고민을 할 수 있어서 좋았어요.")
 	String answer
 
 ) {

--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -10,9 +10,11 @@ import org.layer.domain.answer.entity.Answers;
 import org.layer.domain.answer.repository.AnswerRepository;
 import org.layer.domain.answer.service.dto.request.AnswerCreateServiceRequest;
 import org.layer.domain.answer.service.dto.request.AnswerListCreateServiceRequest;
+import org.layer.domain.common.time.Time;
 import org.layer.domain.question.entity.Questions;
 import org.layer.domain.question.enums.QuestionType;
 import org.layer.domain.question.repository.QuestionRepository;
+import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.layer.domain.space.entity.MemberSpaceRelation;
 import org.layer.domain.space.exception.MemberSpaceRelationException;
@@ -31,6 +33,8 @@ public class AnswerService {
 	private final RetrospectRepository retrospectRepository;
 	private final QuestionRepository questionRepository;
 
+	private final Time time;
+
 	public void create(AnswerListCreateServiceRequest request, Long spaceId, Long retrospectId, Long memberId) {
 		// 스페이스 팀원인지 검증
 		Optional<MemberSpaceRelation> team = memberSpaceRelationRepository.findBySpaceIdAndMemberId(
@@ -40,7 +44,8 @@ public class AnswerService {
 		}
 
 		// 회고 존재 검증
-		retrospectRepository.findByIdOrThrow(retrospectId);
+		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
+		retrospect.validateDeadline(time.now());
 
 		// 회고 질문 유효성 검사 - 해당 회고에 속해있는 질문인지
 		List<Long> questionIds = request.requests().stream()

--- a/layer-api/src/main/java/org/layer/domain/question/controller/QuestionController.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/QuestionController.java
@@ -30,7 +30,7 @@ public class QuestionController implements QuestionApi{
 		List<QuestionGetResponse> responses = questionService.getRetrospectQuestions(spaceId, retrospectId, memberId)
 			.questions()
 			.stream()
-			.map(q -> QuestionGetResponse.of(q.question(), q.order(), q.questionType()))
+			.map(q -> QuestionGetResponse.of(q.questionId(), q.question(), q.order(), q.questionType()))
 			.toList();
 
 		return ResponseEntity.ok().body(QuestionListGetResponse.of(responses));

--- a/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/controller/dto/response/QuestionGetResponse.java
@@ -1,12 +1,17 @@
 package org.layer.domain.question.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "QuestionGetResponse", description = "회고 질문 응답 Dto")
 public record QuestionGetResponse(
+	@Schema(description = "질문 id", example = "1")
+	Long questionId,
+	@Schema(description = "질문 내용", example = "가장 좋았던 점은 무엇이었나요?")
 	String question,
 	int order,
 	String questionType
 ) {
-	public static QuestionGetResponse of(String question, int order, String questionType) {
-		return new QuestionGetResponse(question, order, questionType);
+	public static QuestionGetResponse of(Long questionId, String question, int order, String questionType) {
+		return new QuestionGetResponse(questionId, question, order, questionType);
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
@@ -45,7 +45,7 @@ public class QuestionService {
 			retrospectId, QuestionOwner.TEAM);
 
 		List<QuestionGetServiceResponse> serviceResponses = questions.stream()
-			.map(q -> QuestionGetServiceResponse.of(q.getContent(), q.getQuestionOrder(), q.getQuestionType().getStyle()))
+			.map(q -> QuestionGetServiceResponse.of(q.getQuestionOwnerId(), q.getContent(), q.getQuestionOrder(), q.getQuestionType().getStyle()))
 			.toList();
 
 		return QuestionListGetServiceResponse.of(serviceResponses);

--- a/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionGetServiceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/dto/response/QuestionGetServiceResponse.java
@@ -1,11 +1,12 @@
 package org.layer.domain.question.service.dto.response;
 
 public record QuestionGetServiceResponse(
+	Long questionId,
 	String question,
 	int order,
 	String questionType
 ) {
-	public static QuestionGetServiceResponse of(String question, int order, String questionType) {
-		return new QuestionGetServiceResponse(question, order, questionType);
+	public static QuestionGetServiceResponse of(Long questionId, String question, int order, String questionType) {
+		return new QuestionGetServiceResponse(questionId, question, order, questionType);
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
@@ -36,8 +36,7 @@ public class RetrospectController implements RetrospectApi {
 		@RequestBody @Valid RetrospectCreateRequest request,
 		@MemberId Long memberId) {
 
-		retrospectService.createRetrospect(
-			RetrospectCreateServiceRequest.of(request.title(), request.introduction(), spaceId, request.questions()), memberId);
+		retrospectService.createRetrospect(request, spaceId, memberId);
 
 		return ResponseEntity.ok().build();
 	}
@@ -51,8 +50,8 @@ public class RetrospectController implements RetrospectApi {
 		RetrospectListGetServiceResponse serviceResponse = retrospectService.getRetrospects(spaceId, memberId);
 
 		List<RetrospectGetResponse> retrospectGetResponses = serviceResponse.retrospects().stream()
-			.map(r -> RetrospectGetResponse.of(r.title(), r.introduction(), r.isWrite(), r.retrospectStatus(),
-				r.writeCount()))
+			.map(r -> RetrospectGetResponse.of(r.retrospectId(), r.title(), r.introduction(), r.isWrite(), r.retrospectStatus(),
+				r.writeCount(), r.totalCount()))
 			.toList();
 
 		return ResponseEntity.ok()

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectCreateRequest.java
@@ -1,5 +1,6 @@
 package org.layer.domain.retrospect.controller.dto.request;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,9 @@ public record RetrospectCreateRequest(
 	@Schema(description = "회고 질문 목록(리스트)", example = "이번에 가장 어려웠던 점은 무엇인가요?")
 	@NotNull
 	@Size(min = 3, max = 15)
-	List<String> questions
+	List<String> questions,
+	@Schema(description = "회고 마감 일자", example = "")
+	@NotNull
+	LocalDateTime deadline
 ) {
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/response/RetrospectGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/response/RetrospectGetResponse.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "RetrospectGetResponse", description = "특정 회고 조회 Dto")
 public record RetrospectGetResponse(
+	@Schema(description = "회고 id", example = "1")
+	Long retrospectId,
 	@Schema(description = "회고 이름", example = "중간 발표 이후")
 	String title,
 	@Schema(description = "회고 설명", example = "중간 발표 관련해서 KPT 회고를 해봅시다.")
@@ -15,11 +17,13 @@ public record RetrospectGetResponse(
 	@Schema(description = "회고 상태 : PROCEEDING 나 DONE 중에 하나입니다.", example = "PROCEEDING")
 	RetrospectStatus retrospectStatus,
 	@Schema(description = "해당 회고 응답 수", example = "4")
-	long writeCount
+	long writeCount,
+	@Schema(description = "전체 인원", example = "10")
+	long totalCount
 ) {
-	public static RetrospectGetResponse of(String title, String introduction, boolean isWrite, RetrospectStatus retrospectStatus,
-		long writeCount){
+	public static RetrospectGetResponse of(Long retrospectId, String title, String introduction, boolean isWrite, RetrospectStatus retrospectStatus,
+		long writeCount, long totalCount){
 
-		return new RetrospectGetResponse(title, introduction, isWrite, retrospectStatus, writeCount);
+		return new RetrospectGetResponse(retrospectId, title, introduction, isWrite, retrospectStatus, writeCount, totalCount);
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/response/RetrospectListGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/response/RetrospectListGetResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "RetrospectListGetResponse", description = "회고 목록 조회 Dto")
 public record RetrospectListGetResponse(
-	@Schema(description = "쌓인 레이어 수", example = "3")
+	@Schema(description = "쌓인 회고 수", example = "3")
 	int layerCount,
 	@Schema(description = "회고 객체 목록", example = "")
 	List<RetrospectGetResponse> retrospects

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/dto/response/RetrospectGetServiceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/dto/response/RetrospectGetServiceResponse.java
@@ -3,14 +3,17 @@ package org.layer.domain.retrospect.service.dto.response;
 import org.layer.domain.retrospect.entity.RetrospectStatus;
 
 public record RetrospectGetServiceResponse(
+	Long retrospectId,
 	String title,
 	String introduction,
 	boolean isWrite,
 	RetrospectStatus retrospectStatus,
-	long writeCount
+	long writeCount,
+	long totalCount
 ) {
-	public static RetrospectGetServiceResponse of(String title, String introduction, boolean isWrite,
-		RetrospectStatus retrospectStatus, long writeCount){
-		return new RetrospectGetServiceResponse(title, introduction, isWrite, retrospectStatus, writeCount);
+	public static RetrospectGetServiceResponse of(Long retrospectId, String title, String introduction, boolean isWrite,
+		RetrospectStatus retrospectStatus, long writeCount, long totalCount) {
+		return new RetrospectGetServiceResponse(retrospectId, title, introduction, isWrite, retrospectStatus,
+			writeCount, totalCount);
 	}
 }

--- a/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum RetrospectExceptionType implements ExceptionType{
+	DEADLINE_PASSED(HttpStatus.BAD_REQUEST, "회고 마감기한이 지났습니다."),
 	NOT_PROCEEDING_RETROSPECT(HttpStatus.BAD_REQUEST, "진행중인 회고가 아닙니다."),
 	NOT_FOUND_RETROSPECT(HttpStatus.NOT_FOUND, "유효한 회고가 존재하지 않습니다.");
 

--- a/layer-domain/src/main/java/org/layer/domain/common/time/RealTime.java
+++ b/layer-domain/src/main/java/org/layer/domain/common/time/RealTime.java
@@ -1,0 +1,10 @@
+package org.layer.domain.common.time;
+
+import java.time.LocalDateTime;
+
+public class RealTime implements Time {
+	@Override
+	public LocalDateTime now() {
+		return LocalDateTime.now();
+	}
+}

--- a/layer-domain/src/main/java/org/layer/domain/common/time/Time.java
+++ b/layer-domain/src/main/java/org/layer/domain/common/time/Time.java
@@ -1,0 +1,10 @@
+package org.layer.domain.common.time;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface Time {
+	LocalDateTime now();
+}

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -58,4 +58,10 @@ public class Retrospect extends BaseTimeEntity {
 			throw new RetrospectException(NOT_PROCEEDING_RETROSPECT);
 		}
 	}
+
+	public void validateDeadline(LocalDateTime currentTime) {
+		if (currentTime.isAfter(this.deadline)) {
+			throw new RetrospectException(DEADLINE_PASSED);
+		}
+	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -2,6 +2,8 @@ package org.layer.domain.retrospect.entity;
 
 import static org.layer.common.exception.RetrospectExceptionType.*;
 
+import java.time.LocalDateTime;
+
 import org.layer.domain.common.BaseTimeEntity;
 import org.layer.domain.retrospect.exception.RetrospectException;
 
@@ -21,34 +23,39 @@ import jakarta.validation.constraints.NotNull;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Retrospect extends BaseTimeEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @NotNull
-    private Long spaceId;
+	@NotNull
+	private Long spaceId;
 
-    @NotNull
-    private String title;
+	@NotNull
+	private String title;
 
-    @NotNull
-    private String introduction;
+	@NotNull
+	private String introduction;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private RetrospectStatus retrospectStatus;
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private RetrospectStatus retrospectStatus;
 
-    @Builder
-    public Retrospect(Long spaceId, String title, String introduction, RetrospectStatus retrospectStatus) {
-        this.spaceId = spaceId;
-        this.title = title;
-        this.introduction = introduction;
-        this.retrospectStatus = retrospectStatus;
-    }
+	@NotNull
+	private LocalDateTime deadline;
 
-    public void isProceedingRetrospect(){
-        if(!this.retrospectStatus.equals(RetrospectStatus.PROCEEDING)){
-            throw new RetrospectException(NOT_PROCEEDING_RETROSPECT);
-        }
-    }
+	@Builder
+	public Retrospect(Long spaceId, String title, String introduction, RetrospectStatus retrospectStatus,
+		LocalDateTime deadline) {
+		this.spaceId = spaceId;
+		this.title = title;
+		this.introduction = introduction;
+		this.retrospectStatus = retrospectStatus;
+		this.deadline = deadline;
+	}
+
+	public void isProceedingRetrospect() {
+		if (!this.retrospectStatus.equals(RetrospectStatus.PROCEEDING)) {
+			throw new RetrospectException(NOT_PROCEEDING_RETROSPECT);
+		}
+	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/MemberSpaceRelationRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/MemberSpaceRelationRepository.java
@@ -1,6 +1,7 @@
 package org.layer.domain.space.repository;
 
 
+import java.util.List;
 import java.util.Optional;
 
 import org.layer.domain.space.entity.MemberSpaceRelation;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberSpaceRelationRepository extends JpaRepository<MemberSpaceRelation, Long> {
 
 	Optional<MemberSpaceRelation> findBySpaceIdAndMemberId(Long spaceId, Long memberId);
+
+	List<MemberSpaceRelation> findAllBySpaceId(Long spaceId);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 여러 API 들을 뷰에 맞게 수정했습니다.

- [x] 회고 생성 API : 회고 마감기한 추가, 검증 로직 추가
- [x] 특정 회고 질문 목록 조회 API : 질문 id 추가
- [x] 회고 목록 조회 API : 회고 id 추가

### Time 인터페이스 사용
- 의존성 역전을 사용해서 의존성을 최소화시켰습니다.
- 나중에 테스트 코드 작성할 때도 매우 유용하기에 이렇게 구현했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
