### PR TITLE
feat: presigned URL 이미지 저장 로직 변경

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/external/api/ExternalApi.java
+++ b/layer-api/src/main/java/org/layer/domain/external/api/ExternalApi.java
@@ -16,6 +16,15 @@ public interface ExternalApi {
     @Operation(summary = "Presigned URL 발급받기",
             method = "POST", description = """
             이미지 업로드를 위한 Presigned URL 발급합니다.
+                        
+            - GetPreSignedURLResponse.presignedUrl: 이미지 저장을 위한 요청 URL<br />
+            - GetPreSignedURLResponse.imageUrl:     저장 완료된 이미지 요청 URL
+                        
+            # 참고사항
+                        
+            presigned URL 요청 시 헤더에 담긴 Content-type에 따라 파일의 확장자가 정해집니다.
+            사용처에 따라 정확한 Content-type으로 요청 부탁드립니다.
+                        
             """
     )
     @ApiResponses({

--- a/layer-api/src/main/java/org/layer/domain/external/controller/ExternalController.java
+++ b/layer-api/src/main/java/org/layer/domain/external/controller/ExternalController.java
@@ -1,10 +1,12 @@
 package org.layer.domain.external.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.layer.common.annotation.MemberId;
 import org.layer.domain.external.api.ExternalApi;
 import org.layer.domain.external.dto.ExternalRequest;
 import org.layer.domain.external.dto.ExternalResponse;
+import org.layer.external.ncp.dto.NcpResponse;
 import org.layer.external.ncp.service.NcpService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/external")
 public class ExternalController implements ExternalApi {
 
@@ -23,8 +26,9 @@ public class ExternalController implements ExternalApi {
     @GetMapping("/image/presigned")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ExternalResponse.GetPreSignedURLResponse> getPresignedURL(@MemberId Long memberId, ExternalRequest.GetPreSignedURLRequest getPreSignedURLRequest) {
-        String url = ncpService.getPreSignedUrl(memberId, getPreSignedURLRequest.domain());
+        NcpResponse.PresignedResult presignedResult = ncpService.getPreSignedUrl(memberId, getPreSignedURLRequest.domain());
 
-        return ResponseEntity.ok(ExternalResponse.GetPreSignedURLResponse.toResponse(url));
+
+        return ResponseEntity.ok(ExternalResponse.GetPreSignedURLResponse.toResponse(presignedResult.presignedUrl(), presignedResult.imageUrl()));
     }
 }

--- a/layer-api/src/main/java/org/layer/domain/external/dto/ExternalResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/external/dto/ExternalResponse.java
@@ -14,12 +14,26 @@ public class ExternalResponse {
     @Builder
     @Schema(description = "Presigned URL 응답")
     public record GetPreSignedURLResponse(
-            @Schema(description = "생성된 Presigned URL")
+            @Schema(title = "생성된 Presigned URL", description = """
+                    이미지 저장을 위한 요청 URL<br />
+                    *요청시 보낸 Content-type에 따라 확장자가 결정됩니다*
+                    """)
             @NotNull
-            String url
+            String presignedUrl,
+
+            @Schema(title = "업르드된 이미지 주소", description = """
+                    도메인 별로 엔티티 생성 시 해당 파라미터 객체 유무 확인 로직이 있습니다.
+                    업로드 성공 이후 엔티티 생성 요청 부탁드립니다
+                    """)
+            String imageUrl
     ) {
-        public static GetPreSignedURLResponse toResponse(String url) {
-            return Optional.ofNullable(url).map(it -> GetPreSignedURLResponse.builder().url(url).build()).orElseThrow(() -> new ExternalExeption(INTERNAL_SERVER_ERROR));
+        public static GetPreSignedURLResponse toResponse(String presignedUrl, String imageUrl) {
+            return Optional.ofNullable(presignedUrl)
+                    .map(it -> GetPreSignedURLResponse.builder()
+                            .presignedUrl(presignedUrl)
+                            .imageUrl(imageUrl)
+                            .build()
+                    ).orElseThrow(() -> new ExternalExeption(INTERNAL_SERVER_ERROR));
         }
     }
 }

--- a/layer-external/src/main/java/org/layer/external/ncp/dto/NcpResponse.java
+++ b/layer-external/src/main/java/org/layer/external/ncp/dto/NcpResponse.java
@@ -1,0 +1,19 @@
+package org.layer.external.ncp.dto;
+
+import lombok.Builder;
+
+public class NcpResponse {
+
+    @Builder
+    public record PresignedResult(
+            String presignedUrl,
+            String imageUrl
+    ) {
+
+        public static PresignedResult toResponse(String presignedUrl,
+                                                 String imageUrl) {
+            return PresignedResult.builder().presignedUrl(presignedUrl).imageUrl(imageUrl).build();
+
+        }
+    }
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
presigned URL 요청 시 저장 성공 이후 object 요청 주소가 함께 전달됩니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

![image](https://github.com/user-attachments/assets/8b0938ae-bba8-4b37-b643-2e72e7ecb1aa)



### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->

- closed #49 
