### PR TITLE
fix: 회원 가입이 필요한 상황에서의 응답 내용 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/auth/service/AuthService.java
+++ b/layer-api/src/main/java/org/layer/domain/auth/service/AuthService.java
@@ -34,8 +34,8 @@ public class AuthService {
     public SignInResponse signIn(final String socialAccessToken, final SocialType socialType) {
         MemberInfoServiceResponse signedMember = getMemberInfo(socialType, socialAccessToken);
 
-        // DB에서 회원 찾기. 없다면 Exception 발생 => 이름 입력 창으로
-        Member member = memberService.findMemberBySocialIdAndSocialType(signedMember.socialId(), socialType);
+        // DB에서 회원 찾기. 없다면 NEED_TO_REGISTER Exception 발생 => 이름 입력 창으로
+        Member member = memberService.getMemberBySocialInfoForSignIn(signedMember.socialId(), socialType);
         JwtToken jwtToken = jwtService.issueToken(member.getId(), member.getMemberRole());
         return SignInResponse.of(member, jwtToken);
     }

--- a/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
+++ b/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
@@ -27,9 +27,17 @@ public class MemberService {
     }
 
     // 소셜 아이디와 소셜 타입으로 멤버 찾기. 멤버가 없으면 Exception
-    public Member findMemberBySocialIdAndSocialType(String socialId, SocialType socialType) {
+    // 현재는 사용하지 않음
+    public Member getMemberBySocialIdAndSocialType(String socialId, SocialType socialType) {
         return memberRepository.findBySocialIdAndSocialType(socialId, socialType)
                 .orElseThrow(() -> new BaseCustomException(MemberExceptionType.NOT_FOUND_USER));
+    }
+
+    // sign-in만을 위한 메서드. 멤버가 없을시 회원가입이 필요함을 알려준다.
+    // 회원이 진짜로 없는 error의 경우와 회원 가입이 필요하다는 응답을 구분하기 위함
+    public Member getMemberBySocialInfoForSignIn(String socialId, SocialType socialType) {
+        return memberRepository.findBySocialIdAndSocialType(socialId, socialType)
+                .orElseThrow(() -> new BaseCustomException(MemberExceptionType.NEED_TO_REGISTER));
     }
 
     public void checkIsNewMember(String socialId, SocialType socialType) {

--- a/layer-common/src/main/java/org/layer/common/exception/MemberExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/MemberExceptionType.java
@@ -10,6 +10,7 @@ public enum MemberExceptionType implements ExceptionType {
      * 400
      */
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유효한 유저를 찾지 못했습니다."),
+    NEED_TO_REGISTER(HttpStatus.BAD_REQUEST, "회원가입이 필요합니다."),
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "로그인되지 않은 사용자입니다."),
     FAIL_TO_AUTH(HttpStatus.BAD_REQUEST, "인증에 실패했습니다."),
     NOT_A_NEW_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
유저가 처음 로그인해서 회원가입이 필요한 상황에서
응답 코드와 메시지를 아래 사진처럼 수정했습니다.
수정된 내용:
<img width="845" alt="스크린샷 2024-07-29 오후 6 45 38" src="https://github.com/user-attachments/assets/07e231b4-5128-434e-87a1-923b8b0267b9">

기존 응답 내용:
<img width="847" alt="스크린샷 2024-07-29 오후 7 02 38" src="https://github.com/user-attachments/assets/5bd2810e-074f-460c-a64b-f6e1cacddd04">


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/53 -> develop
- closed #53 
