### PR TITLE
feat : 질문 수정 관련 로직 구현

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -97,7 +97,7 @@ public class AnswerService {
 		answers.validateAlreadyAnswer(memberId, retrospectId);
 
 		// 해당 회고의 모든 질문 조회, 모든 임시답변 조회 -> 질문-임시답변과 매핑
-		List<Question> questions = questionRepository.findAllByQuestionOwnerIdAndQuestionOwnerOrderByQuestionOrder(
+		List<Question> questions = questionRepository.findAllByRetrospectIdAndQuestionOwnerOrderByQuestionOrder(
 			retrospectId, QuestionOwner.TEAM);
 
 		List<TemporaryAnswerGetResponse> temporaryAnswers = questions.stream()

--- a/layer-api/src/main/java/org/layer/domain/form/controller/FormApi.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/FormApi.java
@@ -1,0 +1,17 @@
+package org.layer.domain.form.controller;
+
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.form.controller.dto.response.DefaultFormGetResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "회고 폼(커스텀 템플릿)", description = "회고 폼 관련 API")
+public interface FormApi {
+
+	@Operation(summary = "회고 폼(커스텀 템플릿) 조회 (기본 회고폼 포함)", method = "GET", description = "회고 폼(커스텀 템플릿)을 조회하는 기능입니다.")
+	ResponseEntity<DefaultFormGetResponse> getForm(@PathVariable Long formId, @MemberId Long memberId);
+
+}

--- a/layer-api/src/main/java/org/layer/domain/form/controller/FormController.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/FormController.java
@@ -1,0 +1,28 @@
+package org.layer.domain.form.controller;
+
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.form.controller.dto.response.DefaultFormGetResponse;
+import org.layer.domain.form.service.FormService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/form")
+public class FormController implements FormApi {
+	private final FormService formService;
+
+	@Override
+	@GetMapping("/{formId}")
+	public ResponseEntity<DefaultFormGetResponse> getForm(@PathVariable Long formId, @MemberId Long memberId) {
+		DefaultFormGetResponse dto = formService.getForm(formId, memberId);
+
+		return ResponseEntity.ok().body(dto);
+	}
+
+}

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/DefaultFormGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/DefaultFormGetResponse.java
@@ -1,0 +1,18 @@
+package org.layer.domain.form.controller.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "DefaultFormGetResponse", description = "기본 회고폼(커스텀 템플릿) 조회 응답 Dto")
+public record DefaultFormGetResponse(
+	@Schema(description = "회고폼 이름", example = "KPT 커스텀 회고 폼")
+	String title,
+	@Schema(description = "질문 객체 목록", example = "")
+	List<DefaultQuestionGetResponse> questions
+
+) {
+	public static DefaultFormGetResponse of(String title, List<DefaultQuestionGetResponse> questions){
+		return new DefaultFormGetResponse(title, questions);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/DefaultQuestionGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/DefaultQuestionGetResponse.java
@@ -1,0 +1,15 @@
+package org.layer.domain.form.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "DefaultQuestionGetResponse", description = "기본 회고폼(커스텀 템플릿) 질문 조회 응답 Dto")
+public record DefaultQuestionGetResponse(
+	@Schema(description = "질문 내용", example = "계속 유지하고 싶은 것은 무엇인가요?")
+	String questionContent,
+	@Schema(description = "질문 타입", example = "plain_text")
+	String questionType
+) {
+	public static DefaultQuestionGetResponse of(String questionContent, String questionType){
+		return new DefaultQuestionGetResponse(questionContent, questionType);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
+++ b/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
@@ -1,0 +1,43 @@
+package org.layer.domain.form.service;
+
+import java.util.List;
+
+import org.layer.domain.form.controller.dto.response.DefaultFormGetResponse;
+import org.layer.domain.form.controller.dto.response.DefaultQuestionGetResponse;
+import org.layer.domain.form.entity.Form;
+import org.layer.domain.form.repository.FormRepository;
+import org.layer.domain.question.entity.Question;
+import org.layer.domain.question.repository.QuestionRepository;
+import org.layer.domain.space.entity.Team;
+import org.layer.domain.space.repository.MemberSpaceRelationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FormService {
+	private final FormRepository formRepository;
+	private final MemberSpaceRelationRepository memberSpaceRelationRepository;
+	private final QuestionRepository questionRepository;
+
+	public DefaultFormGetResponse getForm(Long formId, Long memberId){
+		Form form = formRepository.findByIdOrThrow(formId);
+
+		// 해당 스페이스 팀원인지 검증
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(form.getSpaceId()));
+		team.validateTeamMembership(memberId);
+
+		List<Question> questions = questionRepository.findAllByFormId(formId);
+
+		List<DefaultQuestionGetResponse> questionResponses = questions.stream()
+			.map(question -> DefaultQuestionGetResponse.of(question.getContent(),
+				question.getQuestionType().getStyle()))
+			.toList();
+
+		return DefaultFormGetResponse.of(form.getTitle(), questionResponses);
+	}
+
+}

--- a/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
@@ -45,11 +45,11 @@ public class QuestionService {
 		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
 		retrospect.isProceedingRetrospect();
 
-		List<Question> questions = questionRepository.findAllByQuestionOwnerIdAndQuestionOwnerOrderByQuestionOrder(
+		List<Question> questions = questionRepository.findAllByRetrospectIdAndQuestionOwnerOrderByQuestionOrder(
 			retrospectId, QuestionOwner.TEAM);
 
 		List<QuestionGetResponse> responses = questions.stream()
-			.map(q -> QuestionGetResponse.of(q.getQuestionOwnerId(), q.getContent(), q.getQuestionOrder(), q.getQuestionType().getStyle()))
+			.map(q -> QuestionGetResponse.of(q.getId(), q.getContent(), q.getQuestionOrder(), q.getQuestionType().getStyle()))
 			.toList();
 
 		// 임시 저장 여부 확인

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/QuestionCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/QuestionCreateRequest.java
@@ -9,6 +9,6 @@ public record QuestionCreateRequest(
 	@Schema(description = "질문 내용", example = "팀원 간의 소통은 어땠나요?")
 	String questionContent,
 	@Schema(description = "질문 타입", example = "plain_text")
-	QuestionType questionType
+	String questionType
 ) {
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/QuestionCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/QuestionCreateRequest.java
@@ -1,0 +1,14 @@
+package org.layer.domain.retrospect.controller.dto.request;
+
+import org.layer.domain.question.enums.QuestionType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "QuestionCreateRequest", description = "질문 객체 생성 요청 Dto")
+public record QuestionCreateRequest(
+	@Schema(description = "질문 내용", example = "팀원 간의 소통은 어땠나요?")
+	String questionContent,
+	@Schema(description = "질문 타입", example = "plain_text")
+	QuestionType questionType
+) {
+}

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectCreateRequest.java
@@ -14,12 +14,17 @@ public record RetrospectCreateRequest(
 	@Schema(description = "회고 한줄 설명", example = "우리만의 KPT 회고")
 	@NotNull
 	String introduction,
-	@Schema(description = "회고 질문 목록(리스트)", example = "이번에 가장 어려웠던 점은 무엇인가요?")
+	@Schema(description = "회고 질문 객체 목록", example = "")
 	@NotNull
-	@Size(min = 3, max = 15)
-	List<String> questions,
+	List<QuestionCreateRequest> questions,
 	@Schema(description = "회고 마감 일자", example = "")
 	@NotNull
-	LocalDateTime deadline
+	LocalDateTime deadline,
+	@Schema(description = "질문을 수정한 경우 true", example = "true")
+	boolean isNewForm,
+	@Schema(description = "질문을 수정한 경우, 변경된 폼 이름", example = "변경된 커스텀 폼 제목")
+	String formName,
+	@Schema(description = "질문을 수정한 경우, 변경된 폼 한줄 소개", example = "변경된 커스텀 폼 한줄 소개")
+	String formIntroduction
 ) {
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -9,11 +9,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.layer.domain.answer.entity.Answers;
 import org.layer.domain.answer.repository.AnswerRepository;
 import org.layer.domain.form.entity.Form;
+import org.layer.domain.form.entity.FormType;
 import org.layer.domain.form.repository.FormRepository;
 import org.layer.domain.question.entity.Question;
 import org.layer.domain.question.enums.QuestionOwner;
-import org.layer.domain.question.enums.QuestionType;
 import org.layer.domain.question.repository.QuestionRepository;
+import org.layer.domain.retrospect.controller.dto.request.QuestionCreateRequest;
 import org.layer.domain.retrospect.controller.dto.request.RetrospectCreateRequest;
 import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.entity.RetrospectStatus;
@@ -21,9 +22,11 @@ import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.layer.domain.retrospect.service.dto.response.RetrospectGetServiceResponse;
 import org.layer.domain.retrospect.service.dto.response.RetrospectListGetServiceResponse;
 import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.entity.Space;
 import org.layer.domain.space.entity.Team;
 import org.layer.domain.space.exception.MemberSpaceRelationException;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
+import org.layer.domain.space.repository.SpaceRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,38 +42,39 @@ public class RetrospectService {
 	private final QuestionRepository questionRepository;
 	private final AnswerRepository answerRepository;
 	private final FormRepository formRepository;
+	private final SpaceRepository spaceRepository;
 
 	@Transactional
 	public void createRetrospect(RetrospectCreateRequest request, Long spaceId, Long memberId) {
 		// 해당 스페이스 팀원인지 검증
-		validateTeamMember(spaceId, memberId);
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
+		team.validateTeamMembership(memberId);
 
 		Retrospect retrospect = getRetrospect(request, spaceId);
 		Retrospect savedRetrospect = retrospectRepository.save(retrospect);
 
-		AtomicInteger teamIndex = new AtomicInteger(1);
-		List<Question> questions = request.questions().stream()
-			.map(q -> new Question(savedRetrospect.getId(), q, teamIndex.getAndIncrement(), QuestionOwner.TEAM,
-				QuestionType.PLAIN_TEXT))
-			.toList();
+		List<Question> questions = getQuestions(request.questions(), savedRetrospect.getId(), null);
 		questionRepository.saveAll(questions);
 
-		// 내 회고 폼에 추가
-		Form form = new Form(memberId, request.title(), request.introduction());
-		Form savedForm = formRepository.save(form);
+		// 새로운 폼 생성(수정)인지 확인
+		if (request.isNewForm()) {
+			// 내 회고 폼에 추가
+			Form form = new Form(memberId, spaceId, request.title(), request.introduction(), FormType.CUSTOM);
+			Form savedForm = formRepository.save(form);
 
-		AtomicInteger myIndex = new AtomicInteger(1);
-		List<Question> myQuestions = request.questions().stream()
-			.map(q -> new Question(savedForm.getId(), q, myIndex.getAndIncrement(), QuestionOwner.INDIVIDUAL,
-				QuestionType.PLAIN_TEXT))
-			.toList();
-		questionRepository.saveAll(myQuestions);
+			List<Question> myQuestions = getQuestions(request.questions(), null, savedForm.getId());
+			questionRepository.saveAll(myQuestions);
+
+			// 해당 스페이스의 기본 폼 변경
+			Space space = spaceRepository.findByIdOrThrow(spaceId);
+			space.updateFormId(savedForm.getId(), memberId);
+		}
 	}
 
 	private Retrospect getRetrospect(RetrospectCreateRequest request, Long spaceId) {
 		return Retrospect.builder()
-			.title(request.title())
 			.spaceId(spaceId)
+			.title(request.title())
 			.introduction(request.introduction())
 			.retrospectStatus(RetrospectStatus.PROCEEDING)
 			.deadline(request.deadline())
@@ -101,5 +105,20 @@ public class RetrospectService {
 		if (team.isEmpty()) {
 			throw new MemberSpaceRelationException(NOT_FOUND_MEMBER_SPACE_RELATION);
 		}
+	}
+
+	private List<Question> getQuestions(List<QuestionCreateRequest> questions, Long savedRetrospectId, Long formId) {
+		AtomicInteger index = new AtomicInteger(1);
+
+		return questions.stream()
+			.map(question -> Question.builder()
+				.retrospectId(savedRetrospectId)
+				.formId(formId)
+				.content(question.questionContent())
+				.questionOrder(index.getAndIncrement())
+				.questionOwner(QuestionOwner.TEAM)
+				.questionType(question.questionType())
+				.build())
+			.toList();
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -13,6 +13,7 @@ import org.layer.domain.form.entity.FormType;
 import org.layer.domain.form.repository.FormRepository;
 import org.layer.domain.question.entity.Question;
 import org.layer.domain.question.enums.QuestionOwner;
+import org.layer.domain.question.enums.QuestionType;
 import org.layer.domain.question.repository.QuestionRepository;
 import org.layer.domain.retrospect.controller.dto.request.QuestionCreateRequest;
 import org.layer.domain.retrospect.controller.dto.request.RetrospectCreateRequest;
@@ -117,7 +118,7 @@ public class RetrospectService {
 				.content(question.questionContent())
 				.questionOrder(index.getAndIncrement())
 				.questionOwner(QuestionOwner.TEAM)
-				.questionType(question.questionType())
+				.questionType(QuestionType.stringToEnum(question.questionType()))
 				.build())
 			.toList();
 	}

--- a/layer-common/src/main/java/org/layer/common/exception/FormExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/FormExceptionType.java
@@ -1,0 +1,24 @@
+package org.layer.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FormExceptionType implements ExceptionType {
+
+	NOT_FOUND_FORM(HttpStatus.NOT_FOUND, "찾을 수 없는 회고폼(커스텀 템플릿) 입니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus httpStatus() {
+		return status;
+	}
+
+	@Override
+	public String message() {
+		return message;
+	}
+}

--- a/layer-common/src/main/java/org/layer/common/exception/SpaceExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/SpaceExceptionType.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SpaceExceptionType implements ExceptionType{
 	NOT_FOUND_SPACE(HttpStatus.NOT_FOUND, "찾을 수 없는 스페이스 입니다."),
+	UNAUTHORIZED_UPDATE_FORM(HttpStatus.UNAUTHORIZED, "회고폼(커스텀 템플릿) 수정 권한이 없습니다."),
+
 	SPACE_LEADER_CANNOT_LEAVE(BAD_REQUEST, "스페이스를 팀장은 떠날 수 없어요."),
 	SPACE_ALREADY_JOINED(BAD_REQUEST, "이미 가입한 스페이스에요.");
 

--- a/layer-domain/src/main/java/org/layer/domain/actionItem/entity/ActionItem.java
+++ b/layer-domain/src/main/java/org/layer/domain/actionItem/entity/ActionItem.java
@@ -3,18 +3,17 @@ package org.layer.domain.actionItem.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
-import org.layer.domain.BaseEntity;
 import org.layer.domain.actionItem.enums.ActionItemStatus;
 import org.layer.domain.actionItem.exception.ActionItemException;
+import org.layer.domain.common.BaseTimeEntity;
 
 import static org.layer.common.exception.ActionItemExceptionType.CANNOT_DELETE_ACTION_ITEM;
 
 @Getter
-@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class ActionItem extends BaseEntity {
+public class ActionItem extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,7 +34,8 @@ public class ActionItem extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ActionItemStatus actionItemStatus; // 액션 아이템 상태
 
-    public ActionItem(Long retrospectId, Long spaceId, Long memberId, String content, ActionItemStatus actionItemStatus) {
+    @Builder
+    private ActionItem(Long retrospectId, Long spaceId, Long memberId, String content, ActionItemStatus actionItemStatus) {
         this.retrospectId = retrospectId;
         this.spaceId = spaceId;
         this.memberId = memberId;

--- a/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
@@ -1,6 +1,8 @@
 package org.layer.domain.form.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.layer.domain.BaseEntity;
@@ -9,12 +11,16 @@ import org.layer.domain.BaseEntity;
 @Getter
 @Entity
 @EqualsAndHashCode(callSuper = true)
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Form extends BaseEntity {
 
+    /*
+     * 해당 폼 생성한 멤버 id
+     */
     @NotNull
     private Long memberId;
+
+    private Long spaceId;
 
     @NotNull
     private String title;
@@ -22,4 +28,16 @@ public class Form extends BaseEntity {
     @NotNull
     private String introduction;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private FormType formType;
+
+    @Builder
+    public Form(Long memberId, Long spaceId, String title, String introduction, FormType formType) {
+        this.memberId = memberId;
+        this.spaceId = spaceId;
+        this.title = title;
+        this.introduction = introduction;
+        this.formType = formType;
+    }
 }

--- a/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
@@ -32,7 +32,6 @@ public class Form extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private FormType formType;
 
-    @Builder
     public Form(Long memberId, Long spaceId, String title, String introduction, FormType formType) {
         this.memberId = memberId;
         this.spaceId = spaceId;

--- a/layer-domain/src/main/java/org/layer/domain/form/entity/FormType.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/entity/FormType.java
@@ -1,0 +1,5 @@
+package org.layer.domain.form.entity;
+
+public enum FormType {
+	CUSTOM, TEMPLATE
+}

--- a/layer-domain/src/main/java/org/layer/domain/form/exception/FormException.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/exception/FormException.java
@@ -1,0 +1,10 @@
+package org.layer.domain.form.exception;
+
+import org.layer.common.exception.BaseCustomException;
+import org.layer.common.exception.ExceptionType;
+
+public class FormException extends BaseCustomException {
+	public FormException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/layer-domain/src/main/java/org/layer/domain/form/repository/FormRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/repository/FormRepository.java
@@ -1,8 +1,16 @@
 package org.layer.domain.form.repository;
 
+import static org.layer.common.exception.FormExceptionType.*;
+
 import org.layer.domain.form.entity.Form;
+import org.layer.domain.form.exception.FormException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FormRepository extends JpaRepository<Form, Long> {
+	default Form findByIdOrThrow(Long formId) {
+		return findById(formId)
+			.orElseThrow(() -> new FormException(NOT_FOUND_FORM));
+	}
+
 
 }

--- a/layer-domain/src/main/java/org/layer/domain/question/entity/Question.java
+++ b/layer-domain/src/main/java/org/layer/domain/question/entity/Question.java
@@ -3,6 +3,7 @@ package org.layer.domain.question.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.layer.domain.BaseEntity;
@@ -19,10 +20,11 @@ import java.util.Set;
 public class Question extends BaseEntity {
 
     /*
-        questionOwnerId은 retrospectId or memberId 중 하나이다.
+        formId 나 retrospectId 둘 중 하나가 null 이고, 하나는 값이 지정되어야 한다.
     */
-    @NotNull
-    private Long questionOwnerId;
+    private Long formId;
+
+    private Long retrospectId;
 
     @NotNull
     private String content;
@@ -41,8 +43,10 @@ public class Question extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<QuestionOption> options = new HashSet<>();
 
-    public Question(Long questionOwnerId, String content, int questionOrder, QuestionOwner questionOwner, QuestionType questionType) {
-        this.questionOwnerId = questionOwnerId;
+    @Builder
+    private Question(Long formId, Long retrospectId, String content, int questionOrder, QuestionOwner questionOwner, QuestionType questionType) {
+        this.formId = formId;
+        this.retrospectId = retrospectId;
         this.content = content;
         this.questionOrder = questionOrder;
         this.questionOwner = questionOwner;

--- a/layer-domain/src/main/java/org/layer/domain/question/entity/Question.java
+++ b/layer-domain/src/main/java/org/layer/domain/question/entity/Question.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.layer.domain.BaseEntity;
+import org.layer.domain.common.BaseTimeEntity;
 import org.layer.domain.question.enums.QuestionOwner;
 import org.layer.domain.question.enums.QuestionType;
 import org.layer.domain.questionOption.entity.QuestionOption;
@@ -17,7 +17,10 @@ import java.util.Set;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Question extends BaseEntity {
+public class Question extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     /*
         formId 나 retrospectId 둘 중 하나가 null 이고, 하나는 값이 지정되어야 한다.

--- a/layer-domain/src/main/java/org/layer/domain/question/repository/QuestionRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/question/repository/QuestionRepository.java
@@ -7,7 +7,8 @@ import org.layer.domain.question.enums.QuestionOwner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-	List<Question> findAllByQuestionOwnerIdAndQuestionOwnerOrderByQuestionOrder(Long questionOwnerId, QuestionOwner questionOwner);
+	List<Question> findAllByRetrospectIdAndQuestionOwnerOrderByQuestionOrder(Long retrospectId,
+		QuestionOwner questionOwner);
 
 	List<Question> findAllByIdIn(List<Long> questionIds);
 

--- a/layer-domain/src/main/java/org/layer/domain/question/repository/QuestionRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/question/repository/QuestionRepository.java
@@ -10,4 +10,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 	List<Question> findAllByQuestionOwnerIdAndQuestionOwnerOrderByQuestionOrder(Long questionOwnerId, QuestionOwner questionOwner);
 
 	List<Question> findAllByIdIn(List<Long> questionIds);
+
+	List<Question> findAllByFormId(Long formId);
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
@@ -1,5 +1,7 @@
 package org.layer.domain.space.entity;
 
+import static org.layer.common.exception.SpaceExceptionType.*;
+
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +11,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.layer.domain.BaseEntity;
 import org.layer.domain.space.converter.SpaceFieldConverter;
+import org.layer.domain.space.exception.SpaceException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,5 +53,13 @@ public class Space extends BaseEntity {
             return Optional.empty();
         }
         return Optional.of(true);
+    }
+
+    public void updateFormId(Long formId, Long requestMemberId){
+        if(!requestMemberId.equals(leaderId)){
+            throw new SpaceException(UNAUTHORIZED_UPDATE_FORM);
+        }
+
+        this.formId = formId;
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
* [수정] 회고 생성 API : 새로 템플릿 만드는 경우에 대한 값 추가, 새로 만드는 경우 로직 추가
* [새로 구현] 특정 스페이스의 기본 회고폼 조회 API


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 변경된 테이블 설계안
<img width="887" alt="스크린샷 2024-08-01 오전 1 12 02" src="https://github.com/user-attachments/assets/a658d56f-d20a-4dd1-8a03-4d4660b1d367">


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 새로운 커스텀 폼 생성 이전
<img width="1183" alt="스크린샷 2024-08-01 오전 1 03 29" src="https://github.com/user-attachments/assets/e6caa4b1-1899-46ce-b15a-e9ec514c5890">

<img width="1162" alt="스크린샷 2024-08-01 오전 1 04 28" src="https://github.com/user-attachments/assets/acd4bbd7-39e2-4699-b7b9-d85df1cce939">

### 새로운 커스텀 폼 생성 이후
<img width="741" alt="스크린샷 2024-08-01 오전 1 08 30" src="https://github.com/user-attachments/assets/0afe864f-7bc4-4a9a-9909-446770ca179e">
<img width="648" alt="스크린샷 2024-08-01 오전 1 09 25" src="https://github.com/user-attachments/assets/a1c1f328-3fcd-439c-8437-3a1b8747743a">


### 새로운 커스텀 폼 생성 이전 - 기본 회고폼 조회 API
* 에러발생 -> 정상동작
<img width="811" alt="스크린샷 2024-08-01 오전 1 11 16" src="https://github.com/user-attachments/assets/647c4d51-7b3e-4d2d-b9c4-0c8970bd4c5f">


### 새로운 커스텀 폼 생성 이후 - 기본 회고폼 조회 API
<img width="832" alt="스크린샷 2024-08-01 오전 1 10 47" src="https://github.com/user-attachments/assets/5222baa1-84a5-4bc8-9343-8ef7341e13cb">

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#51 -> dev
- closed #51
