### PR TITLE
fix: 회고 임시 저장 조회 로직 npe 오류 해결

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -103,7 +103,7 @@ public class AnswerService {
 
 		List<TemporaryAnswerGetResponse> temporaryAnswers = questions.stream()
 			.map(question -> TemporaryAnswerGetResponse.of(question.getId(), question.getQuestionType().getStyle(), answers.getAnswerToQuestion(
-				question.getId()).getContent()))
+				question.getId())))
 			.toList();
 
 		return TemporaryAnswerListResponse.of(temporaryAnswers);

--- a/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
+++ b/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
@@ -3,6 +3,7 @@ package org.layer.domain.answer.entity;
 import static org.layer.common.exception.AnswerExceptionType.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.layer.domain.answer.exception.AnswerException;
 
@@ -14,10 +15,11 @@ public class Answers {
 
 	private final List<Answer> answers;
 
-	public Answer getAnswerToQuestion(Long questionId){
+	public String getAnswerToQuestion(Long questionId) {
 		return answers.stream()
 			.filter(answer -> answer.getQuestionId().equals(questionId))
-			.findAny()
+			.map(Answer::getContent)
+			.findFirst()
 			.orElse(null);
 	}
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [X] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 조회시 npe 발생하는 에러를 해결했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

<img width="825" alt="스크린샷 2024-08-03 오후 5 21 20" src="https://github.com/user-attachments/assets/f26f618a-9af1-454e-a708-02fab27e9b33">


### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#84 -> dev
- closed #84
