### PR TITLE
feat: 회고폼 수정 및 삭제

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/form/controller/FormApi.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/FormApi.java
@@ -1,12 +1,14 @@
 package org.layer.domain.form.controller;
 
 import org.layer.common.annotation.MemberId;
+import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
 import org.layer.domain.form.controller.dto.response.FormGetResponse;
 import org.layer.domain.form.controller.dto.response.RecommendFormResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,4 +32,10 @@ public interface FormApi {
 	@Operation(summary = "추천 템플릿 조회", method = "GET", description = "추천 템플릿을 조회하는 기능입니다.")
 	ResponseEntity<RecommendFormResponseDto> getRecommendTemplate(@ModelAttribute @Valid @Parameter(hidden = true) RecommendFormQueryDto queryDto,
 		@MemberId Long memberId);
+
+	@Operation(summary = "커스텀 템플릿 제목 수정", method = "PATCH", description = "커스텀 템플릿 제목을 수정합니다.")
+	ResponseEntity<Void> updateFormTitle(@PathVariable Long formId, @RequestBody @Valid FormNameUpdateRequest request, @MemberId Long memberId);
+
+	@Operation(summary = "커스텀 템플릿 삭제", method = "DELETE", description = "커스텀 템플릿을 삭제합니다.")
+	ResponseEntity<Void> deleteFormTitle(@PathVariable Long formId, @MemberId Long memberId);
 }

--- a/layer-api/src/main/java/org/layer/domain/form/controller/FormController.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/FormController.java
@@ -1,14 +1,18 @@
 package org.layer.domain.form.controller;
 
 import org.layer.common.annotation.MemberId;
+import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
 import org.layer.domain.form.controller.dto.response.FormGetResponse;
 import org.layer.domain.form.controller.dto.response.RecommendFormResponseDto;
 import org.layer.domain.form.service.FormService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,6 +41,24 @@ public class FormController implements FormApi {
 
 		RecommendFormResponseDto response = formService.getRecommendTemplate(queryDto, memberId);
 		return ResponseEntity.ok().body(response);
+	}
+
+	@Override
+	@PatchMapping("/{formId}/title")
+	public ResponseEntity<Void> updateFormTitle(@PathVariable Long formId,
+		@RequestBody @Valid FormNameUpdateRequest request, @MemberId Long memberId) {
+		formService.updateFormTitle(formId, request, memberId);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@DeleteMapping("/{formId}")
+	public ResponseEntity<Void> deleteFormTitle(@PathVariable Long formId, @MemberId Long memberId) {
+
+		formService.deleteFormTitle(formId, memberId);
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/request/FormNameUpdateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/request/FormNameUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.layer.domain.form.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "FormNameUpdateRequest", description = "커스템 템플릿 제목 변경 요청 queryParam")
+public record FormNameUpdateRequest(
+	@NotNull
+	@Schema(description = "수정된 회고 제목", example = "수정된 회고 제목입니다.")
+	String formTitle
+) {
+}

--- a/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
+++ b/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
@@ -3,6 +3,7 @@ package org.layer.domain.form.service;
 import java.util.List;
 import java.util.Random;
 
+import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
 import org.layer.domain.form.controller.dto.response.FormGetResponse;
 import org.layer.domain.form.controller.dto.response.QuestionGetResponse;
@@ -12,8 +13,10 @@ import org.layer.domain.form.entity.FormType;
 import org.layer.domain.form.repository.FormRepository;
 import org.layer.domain.question.entity.Question;
 import org.layer.domain.question.repository.QuestionRepository;
+import org.layer.domain.space.entity.Space;
 import org.layer.domain.space.entity.Team;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
+import org.layer.domain.space.repository.SpaceRepository;
 import org.layer.domain.tag.entity.Tag;
 import org.layer.domain.tag.repository.TagRepository;
 import org.springframework.stereotype.Service;
@@ -29,6 +32,7 @@ public class FormService {
 	private final MemberSpaceRelationRepository memberSpaceRelationRepository;
 	private final QuestionRepository questionRepository;
 	private final TagRepository tagRepository;
+	private final SpaceRepository spaceRepository;
 
 	private static final int MIN = 10000;
 	private static final int MAX = 10002;
@@ -64,6 +68,30 @@ public class FormService {
 		// TODO: 템플릿 이미지 필요
 
 		return RecommendFormResponseDto.of(form, tags);
+	}
+
+	public void updateFormTitle(Long formId, FormNameUpdateRequest request, Long memberId){
+		Form form = formRepository.findByIdOrThrow(formId);
+
+		validateIsLeader(memberId, form);
+
+		form.updateFormTitle(request.formTitle());
+	}
+
+	public void deleteFormTitle(Long formId, Long memberId){
+		Form form = formRepository.findByIdOrThrow(formId);
+
+		validateIsLeader(memberId, form);
+
+		formRepository.delete(form);
+	}
+
+	private void validateIsLeader(Long memberId, Form form) {
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(form.getSpaceId()));
+		team.validateTeamMembership(memberId);
+
+		Space space = spaceRepository.findByIdOrThrow(form.getSpaceId());
+		space.isLeaderSpace(memberId);
 	}
 
 }

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -111,8 +111,7 @@ public class SpaceService {
         /*
           스페이스 팀장 여부 확인
          */
-        foundSpace.isLeaderSpace(memberId)
-                .orElseThrow(() -> new SpaceException(SPACE_LEADER_CANNOT_LEAVE));
+        foundSpace.isLeaderSpace(memberId);
 
         /*
           개인 스페이스의 경우, 이탈 시 Space 엔티티의 로직이 된다.

--- a/layer-common/src/main/java/org/layer/common/exception/FormExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/FormExceptionType.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FormExceptionType implements ExceptionType {
 
+	UNAUTHORIZED_UPDATE_FORM(HttpStatus.UNAUTHORIZED, "회고 폼 수정 권한이 없습니다."),
 	NOT_FOUND_FORM(HttpStatus.NOT_FOUND, "찾을 수 없는 회고폼(커스텀 템플릿) 입니다.");
 
 	private final HttpStatus status;

--- a/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
@@ -1,12 +1,15 @@
 package org.layer.domain.form.entity;
 
+import static org.layer.common.exception.FormExceptionType.*;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.layer.domain.BaseEntity;
 
+import org.layer.domain.BaseEntity;
+import org.layer.domain.form.exception.FormException;
 
 @Getter
 @Entity
@@ -14,28 +17,32 @@ import org.layer.domain.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Form extends BaseEntity {
 
-    /*
-     * 해당 폼 생성한 멤버 id
-     */
-    private Long memberId;
+	/*
+	 * 해당 폼 생성한 멤버 id
+	 */
+	private Long memberId;
 
-    private Long spaceId;
+	private Long spaceId;
 
-    @NotNull
-    private String title;
+	@NotNull
+	private String title;
 
-    @NotNull
-    private String introduction;
+	@NotNull
+	private String introduction;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private FormType formType;
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private FormType formType;
 
-    public Form(Long memberId, Long spaceId, String title, String introduction, FormType formType) {
-        this.memberId = memberId;
-        this.spaceId = spaceId;
-        this.title = title;
-        this.introduction = introduction;
-        this.formType = formType;
-    }
+	public Form(Long memberId, Long spaceId, String title, String introduction, FormType formType) {
+		this.memberId = memberId;
+		this.spaceId = spaceId;
+		this.title = title;
+		this.introduction = introduction;
+		this.formType = formType;
+	}
+
+	public void updateFormTitle(String title) {
+		this.title = title;
+	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
@@ -48,10 +48,10 @@ public class Space extends BaseEntity {
      */
     private Long formId;
 
-    public Optional<Boolean> isLeaderSpace(Long memberId) {
-        if (leaderId.equals(memberId)) {
-            return Optional.empty();
+    public void isLeaderSpace(Long memberId) {
+        boolean isLeader = leaderId.equals(memberId);
+        if (!isLeader) {
+            throw new SpaceException(SPACE_LEADER_CANNOT_LEAVE);
         }
-        return Optional.of(true);
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고폼 수정 및 삭제 로직 구현했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 회고폼 제목 수정
<img width="853" alt="스크린샷 2024-08-03 오후 9 11 15" src="https://github.com/user-attachments/assets/fdb1b46d-1825-4d1e-ae73-3141709a3c03">
<img width="703" alt="스크린샷 2024-08-03 오후 9 14 38" src="https://github.com/user-attachments/assets/ba9727f4-b4a8-4855-8eaa-c3b590e0ff90">

### 회고폼 삭제
<img width="823" alt="스크린샷 2024-08-03 오후 9 15 51" src="https://github.com/user-attachments/assets/491f522e-52ef-4078-b99e-6087b793c2e7">
<img width="693" alt="스크린샷 2024-08-03 오후 9 16 01" src="https://github.com/user-attachments/assets/14f05c44-a11d-461e-a3d1-fd5facd4af07">


### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#90 -> dev
- closed #90
