### PR TITLE
feat: 멤버 정보 변경 API 작성

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/member/controller/MemberApi.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/MemberApi.java
@@ -1,0 +1,17 @@
+package org.layer.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.form.controller.dto.response.FormGetResponse;
+import org.layer.domain.member.controller.dto.UpdateMemberInfoRequest;
+import org.layer.domain.member.controller.dto.UpdateMemberInfoResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "회원 서비스", description = "회원 관련 api")
+public interface MemberApi {
+    @Operation(summary = "회원 정보(이름, 프로필 사진) 수정", method = "POST", description = "회원의 이름과 프로필 사진(url)을 수정합니다.")
+    ResponseEntity<UpdateMemberInfoResponse> updateMemberInfo(@MemberId Long memberId, @Valid UpdateMemberInfoRequest updateMemberInfoRequest);
+
+}

--- a/layer-api/src/main/java/org/layer/domain/member/controller/MemberController.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package org.layer.domain.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.layer.common.annotation.MemberId;
+import org.layer.domain.member.controller.dto.UpdateMemberInfoRequest;
+import org.layer.domain.member.controller.dto.UpdateMemberInfoResponse;
+import org.layer.domain.member.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+@RestController
+public class MemberController implements MemberApi {
+    private final MemberService memberService;
+
+    @Override
+    @PostMapping("/update-profile")
+    public ResponseEntity<UpdateMemberInfoResponse> updateMemberInfo(@MemberId Long memberId, @Valid @RequestBody UpdateMemberInfoRequest updateMemberInfoRequest) {
+        UpdateMemberInfoResponse response = memberService.updateMemberInfo(memberId, updateMemberInfoRequest);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/layer-api/src/main/java/org/layer/domain/member/controller/MemberController.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/MemberController.java
@@ -8,10 +8,7 @@ import org.layer.domain.member.controller.dto.UpdateMemberInfoResponse;
 import org.layer.domain.member.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/member")
 @RequiredArgsConstructor
@@ -20,7 +17,7 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @Override
-    @PostMapping("/update-profile")
+    @PatchMapping("/update-profile")
     public ResponseEntity<UpdateMemberInfoResponse> updateMemberInfo(@MemberId Long memberId, @Valid @RequestBody UpdateMemberInfoRequest updateMemberInfoRequest) {
         UpdateMemberInfoResponse response = memberService.updateMemberInfo(memberId, updateMemberInfoRequest);
 

--- a/layer-api/src/main/java/org/layer/domain/member/controller/dto/UpdateMemberInfoRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/dto/UpdateMemberInfoRequest.java
@@ -1,0 +1,14 @@
+package org.layer.domain.member.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "변경할 회원 정보")
+public record UpdateMemberInfoRequest(@NotNull
+                                       @Schema(description = "변경할 이름")
+                                       String name,
+                                       @Schema(description = "변경할 이미지 url")
+                                       String profileImageUrl) {
+}

--- a/layer-api/src/main/java/org/layer/domain/member/controller/dto/UpdateMemberInfoResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/dto/UpdateMemberInfoResponse.java
@@ -1,0 +1,16 @@
+package org.layer.domain.member.controller.dto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "정보가 변경된 회원")
+public record UpdateMemberInfoResponse(@NotNull
+                                       @Schema(description = "정보가 변경된 회원 ID")
+                                       Long memberId,
+                                       @NotNull
+                                       @Schema(description = "변경된 이름")
+                                       String name,
+                                       @Schema(description = "변경된 이미지 url")
+                                       String profileImageUrl) {
+}

--- a/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
+++ b/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
@@ -93,6 +93,7 @@ public class MemberService {
 
 
         return UpdateMemberInfoResponse.builder()
+                .memberId(member.getId())
                 .name(member.getName())
                 .profileImageUrl(member.getProfileImageUrl())
                 .build();

--- a/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
+++ b/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
@@ -5,11 +5,14 @@ import org.layer.common.exception.BaseCustomException;
 import org.layer.common.exception.MemberExceptionType;
 import org.layer.domain.auth.controller.dto.SignUpRequest;
 import org.layer.domain.jwt.SecurityUtil;
+import org.layer.domain.member.controller.dto.UpdateMemberInfoRequest;
+import org.layer.domain.member.controller.dto.UpdateMemberInfoResponse;
 import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.entity.SocialType;
 import org.layer.domain.member.repository.MemberRepository;
 import org.layer.oauth.dto.service.MemberInfoServiceResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -48,6 +51,7 @@ public class MemberService {
         }
     }
 
+    @Transactional
     public Member saveMember(SignUpRequest signUpRequest, MemberInfoServiceResponse memberInfo) {
         Member member = Member.builder()
                 .name(signUpRequest.name())
@@ -74,9 +78,23 @@ public class MemberService {
                 .orElseThrow(() -> new BaseCustomException(NOT_FOUND_USER));
     }
 
+    @Transactional
     public void withdrawMember(Long memberId) {
         Member currentMember = getCurrentMember();
         memberRepository.delete(currentMember);
     }
 
+
+    @Transactional
+    public UpdateMemberInfoResponse updateMemberInfo(Long memberId, UpdateMemberInfoRequest updateMemberInfoRequest) {
+        Member member = memberRepository.findByIdOrThrow(memberId);
+        member.updateName(updateMemberInfoRequest.name());
+        member.updateProfileImageUrl(updateMemberInfoRequest.profileImageUrl());
+
+
+        return UpdateMemberInfoResponse.builder()
+                .name(member.getName())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
 }

--- a/layer-domain/src/main/java/org/layer/domain/form/enums/FormPublishedBy.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/enums/FormPublishedBy.java
@@ -9,7 +9,7 @@ public enum FormPublishedBy {
 
     ADMIN("관리자","0"),
     PERSONAL("개인","1");
-    ;
+
     private String description;
     private String code;
 

--- a/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
@@ -1,19 +1,11 @@
 package org.layer.domain.member.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.validation.Valid;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -33,14 +25,14 @@ public class Member {
     @Enumerated(value = EnumType.STRING)
     private MemberRole memberRole;
 
-    @Valid
     @NotNull
     @Enumerated(value = EnumType.STRING)
     private SocialType socialType;
 
-    @Valid
     @NotNull
     private String socialId;
+
+    private String profileImageUrl;
 
 
     @Builder(access = AccessLevel.PUBLIC)
@@ -51,5 +43,13 @@ public class Member {
         this.memberRole = memberRole;
         this.socialType = socialType;
         this.socialId = socialId;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepository.java
@@ -2,10 +2,17 @@ package org.layer.domain.member.repository;
 
 import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.entity.SocialType;
+import org.layer.domain.member.exception.MemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+import static org.layer.common.exception.MemberExceptionType.NOT_FOUND_USER;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+
+    default Member findByIdOrThrow(Long memberId) {
+        return findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_USER));
+    }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회원의 이름, 프로필 사진을 변경하는 API를 작성했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="611" alt="스크린샷 2024-08-04 오전 12 16 22" src="https://github.com/user-attachments/assets/9988f89f-f4f7-4946-a753-7ef0cf5ead11">
<img width="845" alt="스크린샷 2024-08-04 오전 12 16 51" src="https://github.com/user-attachments/assets/f3a8f6b3-dd5c-4e91-ab5b-185cd95d9a1a">
<img width="606" alt="스크린샷 2024-08-04 오전 12 16 59" src="https://github.com/user-attachments/assets/6c50e982-4b77-4f9b-87c4-1f34037fe680">



### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/98
- closed #98 

