### PR TITLE
feat: 회고 조회 응답 필드 추가하기 (#105)

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
@@ -45,7 +45,7 @@ public class RetrospectController implements RetrospectApi {
 
         List<RetrospectGetResponse> retrospectGetResponses = serviceResponse.retrospects().stream()
                 .map(r -> RetrospectGetResponse.of(r.retrospectId(), r.title(), r.introduction(), r.isWrite(), r.retrospectStatus(),
-                        r.writeCount(), r.totalCount()))
+                        r.writeCount(), r.totalCount(), r.createdAt(), r.deadline()))
                 .toList();
 
         return ResponseEntity.ok()

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/response/RetrospectGetResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/response/RetrospectGetResponse.java
@@ -1,29 +1,36 @@
 package org.layer.domain.retrospect.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.layer.domain.retrospect.entity.RetrospectStatus;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 
 @Schema(name = "RetrospectGetResponse", description = "특정 회고 조회 Dto")
 public record RetrospectGetResponse(
-	@Schema(description = "회고 id", example = "1")
-	Long retrospectId,
-	@Schema(description = "회고 이름", example = "중간 발표 이후")
-	String title,
-	@Schema(description = "회고 설명", example = "중간 발표 관련해서 KPT 회고를 해봅시다.")
-	String introduction,
-	@Schema(description = "회고 작성 여부", example = "false")
-	boolean isWrite,
-	@Schema(description = "회고 상태 : PROCEEDING 나 DONE 중에 하나입니다.", example = "PROCEEDING")
-	RetrospectStatus retrospectStatus,
-	@Schema(description = "해당 회고 응답 수", example = "4")
-	long writeCount,
-	@Schema(description = "전체 인원", example = "10")
-	long totalCount
-) {
-	public static RetrospectGetResponse of(Long retrospectId, String title, String introduction, boolean isWrite, RetrospectStatus retrospectStatus,
-		long writeCount, long totalCount){
+        @Schema(description = "회고 id", example = "1")
+        Long retrospectId,
+        @Schema(description = "회고 이름", example = "중간 발표 이후")
+        String title,
+        @Schema(description = "회고 설명", example = "중간 발표 관련해서 KPT 회고를 해봅시다.")
+        String introduction,
+        @Schema(description = "회고 작성 여부", example = "false")
+        boolean isWrite,
+        @Schema(description = "회고 상태 : PROCEEDING 나 DONE 중에 하나입니다.", example = "PROCEEDING")
+        RetrospectStatus retrospectStatus,
+        @Schema(description = "해당 회고 응답 수", example = "4")
+        long writeCount,
+        @Schema(description = "전체 인원", example = "10")
+        long totalCount,
 
-		return new RetrospectGetResponse(retrospectId, title, introduction, isWrite, retrospectStatus, writeCount, totalCount);
-	}
+        @Schema(description = "회고 생성 일자")
+        LocalDateTime createdAt,
+
+        @Schema(description = "회고 종료 일자")
+        LocalDateTime deadline
+) {
+    public static RetrospectGetResponse of(Long retrospectId, String title, String introduction, boolean isWrite, RetrospectStatus retrospectStatus,
+                                           long writeCount, long totalCount, LocalDateTime createdAt, LocalDateTime deadline) {
+
+        return new RetrospectGetResponse(retrospectId, title, introduction, isWrite, retrospectStatus, writeCount, totalCount, createdAt, deadline);
+    }
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -66,7 +66,7 @@ public class RetrospectService {
             questionRepository.saveAll(myQuestions);
 
             List<Tag> newTags = tagRepository.findAllByFormId(request.curFormId()).stream()
-                .map(tag -> new Tag(tag.getTagName(), savedForm.getId(), null)).toList();
+                    .map(tag -> new Tag(tag.getTagName(), savedForm.getId(), null)).toList();
             tagRepository.saveAll(newTags);
 
         }
@@ -95,7 +95,7 @@ public class RetrospectService {
         List<RetrospectGetServiceResponse> retrospectDtos = retrospects.stream()
                 .map(r -> RetrospectGetServiceResponse.of(r.getId(), r.getTitle(), r.getIntroduction(),
                         answers.hasRetrospectAnswer(memberId, r.getId()), r.getRetrospectStatus(),
-                        answers.getWriteCount(r.getId()), team.getTeamMemberCount()))
+                        answers.getWriteCount(r.getId()), team.getTeamMemberCount(), r.getCreatedAt(), r.getDeadline()))
                 .toList();
 
         return RetrospectListGetServiceResponse.of(retrospects.size(), retrospectDtos);

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/dto/response/RetrospectGetServiceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/dto/response/RetrospectGetServiceResponse.java
@@ -2,18 +2,24 @@ package org.layer.domain.retrospect.service.dto.response;
 
 import org.layer.domain.retrospect.entity.RetrospectStatus;
 
+import java.time.LocalDateTime;
+
 public record RetrospectGetServiceResponse(
-	Long retrospectId,
-	String title,
-	String introduction,
-	boolean isWrite,
-	RetrospectStatus retrospectStatus,
-	long writeCount,
-	long totalCount
+        Long retrospectId,
+        String title,
+        String introduction,
+        boolean isWrite,
+        RetrospectStatus retrospectStatus,
+        long writeCount,
+        long totalCount,
+
+        LocalDateTime createdAt,
+
+        LocalDateTime deadline
 ) {
-	public static RetrospectGetServiceResponse of(Long retrospectId, String title, String introduction, boolean isWrite,
-		RetrospectStatus retrospectStatus, long writeCount, long totalCount) {
-		return new RetrospectGetServiceResponse(retrospectId, title, introduction, isWrite, retrospectStatus,
-			writeCount, totalCount);
-	}
+    public static RetrospectGetServiceResponse of(Long retrospectId, String title, String introduction, boolean isWrite,
+                                                  RetrospectStatus retrospectStatus, long writeCount, long totalCount, LocalDateTime createdAt, LocalDateTime deadline) {
+        return new RetrospectGetServiceResponse(retrospectId, title, introduction, isWrite, retrospectStatus,
+                writeCount, totalCount, createdAt, deadline);
+    }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
회고 조회 시 생성일자와 종료일자를 응답하도록 수정했어요.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
