### PR TITLE
feat: 스페이스에 속한 커스텀 폼 목록 조회

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/form/controller/FormApi.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/FormApi.java
@@ -3,8 +3,10 @@ package org.layer.domain.form.controller;
 import org.layer.common.annotation.MemberId;
 import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
+import org.layer.domain.form.controller.dto.response.CustomTemplateListResponse;
 import org.layer.domain.form.controller.dto.response.FormGetResponse;
 import org.layer.domain.form.controller.dto.response.RecommendFormResponseDto;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,4 +40,7 @@ public interface FormApi {
 
 	@Operation(summary = "커스텀 템플릿 삭제", method = "DELETE", description = "커스텀 템플릿을 삭제합니다.")
 	ResponseEntity<Void> deleteFormTitle(@PathVariable Long formId, @MemberId Long memberId);
+
+	@Operation(summary = "스페이스에 속한 커스텀 템플릿 목록 조회", method = "GET", description = "스페이스의 커스텀 템플릿을 모두 조회합니다. (스페이스에 속한 팀원이라면 조회 가능)")
+	ResponseEntity<CustomTemplateListResponse> getCustomTemplateList(Pageable pageable, @PathVariable Long spaceId, @MemberId Long memberId);
 }

--- a/layer-api/src/main/java/org/layer/domain/form/controller/FormController.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/FormController.java
@@ -1,23 +1,19 @@
 package org.layer.domain.form.controller;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.layer.common.annotation.MemberId;
 import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
+import org.layer.domain.form.controller.dto.response.CustomTemplateListResponse;
 import org.layer.domain.form.controller.dto.response.FormGetResponse;
 import org.layer.domain.form.controller.dto.response.RecommendFormResponseDto;
 import org.layer.domain.form.service.FormService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -61,4 +57,10 @@ public class FormController implements FormApi {
 		return ResponseEntity.ok().build();
 	}
 
+	@Override
+	@GetMapping("/space/{spaceId}/custom-template")
+	public ResponseEntity<CustomTemplateListResponse> getCustomTemplateList(@PageableDefault(size=10) Pageable pageable, @PathVariable(name = "spaceId") Long spaceId, @MemberId Long memberId) {
+		CustomTemplateListResponse response = formService.getCustomTemplateList(pageable, spaceId, memberId);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
 }

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateListResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateListResponse.java
@@ -9,10 +9,10 @@ import org.springframework.data.domain.Page;
 @Schema(name = "CustomFormGetResponse", description = "커스텀 템플릿 조회 응답 Dto")
 public record CustomTemplateListResponse(
         @NotNull
-        @Schema(description = "스페이스 아이디", example = "KPT 커스텀 회고 폼")
+        @Schema(description = "스페이스 아이디", example = "1")
         Long spaceId,
         @NotNull
-        @Schema(description = "커스템 템플릿 객체 목록") // TODO: example 추가
+        @Schema(description = "커스템 템플릿 객체 목록")
         Page<CustomTemplateResponse> customTemplateList
 
 ) {

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateListResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateListResponse.java
@@ -1,0 +1,19 @@
+package org.layer.domain.form.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+@Schema(name = "CustomFormGetResponse", description = "커스텀 템플릿 조회 응답 Dto")
+public record CustomTemplateListResponse(
+        @NotNull
+        @Schema(description = "스페이스 아이디", example = "KPT 커스텀 회고 폼")
+        Long spaceId,
+        @NotNull
+        @Schema(description = "커스템 템플릿 객체 목록") // TODO: example 추가
+        Page<CustomTemplateResponse> customTemplateList
+
+) {
+}

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateListResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateListResponse.java
@@ -9,11 +9,7 @@ import org.springframework.data.domain.Page;
 @Schema(name = "CustomFormGetResponse", description = "커스텀 템플릿 조회 응답 Dto")
 public record CustomTemplateListResponse(
         @NotNull
-        @Schema(description = "스페이스 아이디", example = "1")
-        Long spaceId,
-        @NotNull
         @Schema(description = "커스템 템플릿 객체 목록")
         Page<CustomTemplateResponse> customTemplateList
-
 ) {
 }

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateResponse.java
@@ -1,0 +1,22 @@
+package org.layer.domain.form.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(name = "DefaultFormGetResponse", description = "커스텀 템플릿 조회 간단 정보 응답 Dto")
+public record CustomTemplateResponse(
+        @NotNull
+        @Schema(description = "회고폼 이름", example = "Mad Sad Glad 커스텀 템플릿")
+        String title,
+        @NotNull
+        @Schema(description = "태그", example = "Mad Sad Glad")
+        String formTag,
+        @NotNull
+        @Schema(description = "폼 생성일자", example = "")
+        LocalDateTime createdAt
+) {
+}

--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateResponse.java
@@ -16,7 +16,7 @@ public record CustomTemplateResponse(
         @Schema(description = "태그", example = "Mad Sad Glad")
         String formTag,
         @NotNull
-        @Schema(description = "폼 생성일자", example = "")
+        @Schema(description = "폼 생성일자", example = "2024-08-03T21:40:52.880535")
         LocalDateTime createdAt
 ) {
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/QuestionCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/QuestionCreateRequest.java
@@ -1,8 +1,10 @@
 package org.layer.domain.retrospect.controller.dto.request;
 
-import org.layer.domain.question.enums.QuestionType;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.layer.domain.form.controller.dto.response.CustomTemplateResponse;
+import org.layer.domain.form.enums.FormTag;
+
+import java.time.LocalDateTime;
 
 @Schema(name = "QuestionCreateRequest", description = "질문 객체 생성 요청 Dto")
 public record QuestionCreateRequest(
@@ -11,4 +13,12 @@ public record QuestionCreateRequest(
 	@Schema(description = "질문 타입", example = "plain_text")
 	String questionType
 ) {
+
+	public static CustomTemplateResponse of(String title, FormTag formTag, LocalDateTime createdAt) {
+		return CustomTemplateResponse.builder()
+				.title(title)
+				.formTag(formTag.getTag())
+				.createdAt(createdAt)
+				.build();
+	}
 }

--- a/layer-common/src/main/java/org/layer/common/exception/FormExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/FormExceptionType.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum FormExceptionType implements ExceptionType {
 
 	UNAUTHORIZED_UPDATE_FORM(HttpStatus.UNAUTHORIZED, "회고 폼 수정 권한이 없습니다."),
+	UNAUTHORIZED_GET_FORM(HttpStatus.UNAUTHORIZED, "회고 폼 조회 권한이 없습니다."),
 	NOT_FOUND_FORM(HttpStatus.NOT_FOUND, "찾을 수 없는 회고폼(커스텀 템플릿) 입니다.");
 
 	private final HttpStatus status;

--- a/layer-domain/src/main/java/org/layer/domain/form/repository/FormRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/repository/FormRepository.java
@@ -3,6 +3,8 @@ package org.layer.domain.form.repository;
 import org.layer.domain.form.entity.Form;
 import org.layer.domain.form.entity.FormType;
 import org.layer.domain.form.exception.FormException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -17,5 +19,6 @@ public interface FormRepository extends JpaRepository<Form, Long> {
 
 	List<Form> findByFormTypeOrderById(FormType formType);
 
+	Page<Form> findAllByFormTypeOrderByIdDesc(Pageable pageable, FormType formType);
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 특정 스페이스에 속한 커스텀 폼 목록을 최신순으로 불러오는 api를 작성했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 184번 스페이스에 속한 유저가 커스텀 폼 목록 조회
<img width="846" alt="스크린샷 2024-08-04 오전 2 59 26" src="https://github.com/user-attachments/assets/620fc740-7c69-47c5-a22f-0402a39aeaea">

### 스페이스에 속해있지 않은 경우
<img width="850" alt="스크린샷 2024-08-04 오전 3 06 56" src="https://github.com/user-attachments/assets/2a055912-e6c7-4577-a025-ecc026f320d3">



### 발생한 쿼리 첨부
```sql
Hibernate: 
    select
        msr1_0.id,
        msr1_0.created_at,
        msr1_0.member_id,
        msr1_0.space_id,
        msr1_0.updated_at 
    from
        member_space_relation msr1_0 
    where
        msr1_0.space_id=? 
        and msr1_0.member_id=?
Hibernate: 
    select
        f1_0.id,
        f1_0.created_at,
        f1_0.form_tag,
        f1_0.form_type,
        f1_0.introduction,
        f1_0.member_id,
        f1_0.space_id,
        f1_0.title,
        f1_0.updated_at 
    from
        form f1_0 
    where
        f1_0.form_type=? 
    order by
        f1_0.id desc 
    limit
        ?, ?
Hibernate: 
    select
        count(f1_0.id) 
    from
        form f1_0 
    where
        f1_0.form_type=?

```

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/103
- closed #103 
