### PR TITLE
feat:스페이스 팀원 목록 조회하기 (#107)

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceApi.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceApi.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+
 @Tag(name = "스페이스 API")
 public interface SpaceApi {
     @Operation(summary = "내가 속한 스페이스 조회하기", method = "GET", description = """
@@ -196,4 +198,18 @@ public interface SpaceApi {
     })
     ResponseEntity<Void> kickMemberFromSpace(@MemberId Long memberId, SpaceRequest.KickMemberFromSpaceRequest kickMemberFromSpaceRequest);
 
+
+    @Operation(summary = "스페이스 팀원 목록 조회하기", method = "GET", description = """
+            스페이스에 속한 팀원 목록을 조회합니다.
+            스페이스 멤버만 조회 가능합니다.
+                        
+            - 스페이스 리더가 첫번째 인덱스로 조회됩니다.
+            - 스페이스 가입이 빠른 순서로 조회됩니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = {
+                    @Content(mediaType = "application/json", schema = @Schema)
+            })
+    })
+    ResponseEntity<List<SpaceResponse.SpaceMemberResponse>> getSpaceMembers(@MemberId Long memberId, @PathVariable Long spaceId);
 }

--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @Slf4j
 @RestController
@@ -79,6 +81,13 @@ public class SpaceController implements SpaceApi {
         spaceService.kickMemberFromSpace(memberId, kickMemberFromSpaceRequest.spaceId(), kickMemberFromSpaceRequest.memberId());
         return ResponseEntity.ok().build();
 
+    }
+
+    @Override
+    @GetMapping("members/{spaceId}")
+    public ResponseEntity<List<SpaceResponse.SpaceMemberResponse>> getSpaceMembers(@MemberId Long memberId, @PathVariable Long spaceId) {
+        var spaceMembers = spaceService.getSpaceMembers(memberId, spaceId);
+        return ResponseEntity.ok(spaceMembers);
     }
 }
 

--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
@@ -1,18 +1,21 @@
 package org.layer.domain.space.controller.dto;
 
-import static org.layer.common.exception.TokenExceptionType.*;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import org.layer.common.dto.Meta;
 import org.layer.common.exception.BaseCustomException;
+import org.layer.domain.space.dto.SpaceMember;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
 import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.entity.SpaceField;
+import org.layer.domain.space.exception.SpaceException;
 
 import java.util.List;
 import java.util.Optional;
+
+import static org.layer.common.exception.MemberExceptionType.NOT_FOUND_USER;
+import static org.layer.common.exception.TokenExceptionType.INVALID_REFRESH_TOKEN;
 
 
 public class SpaceResponse {
@@ -88,5 +91,32 @@ public class SpaceResponse {
                     """)
             Long spaceId
     ) {
+    }
+
+    @Builder
+    @Schema
+    public record SpaceMemberResponse(
+            @Schema(title = "맴버 아이디")
+            Long id,
+            @Schema(title = "멤버 프로필 사진")
+            String avatar,
+
+            @Schema(title = "멤버 이름")
+            String name,
+
+            @Schema(title = "스페이스 리더 여부")
+            Boolean isLeader
+    ) {
+        public static SpaceMemberResponse toResponse(SpaceMember spaceMember) {
+            return Optional.ofNullable(spaceMember)
+                    .map(it -> SpaceMemberResponse
+                            .builder()
+                            .id(spaceMember.getId())
+                            .name(spaceMember.getName())
+                            .avatar(spaceMember.getAvatar())
+                            .isLeader(spaceMember.getIsLeader())
+                            .build())
+                    .orElseThrow(() -> new SpaceException(NOT_FOUND_USER));
+        }
     }
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceMember.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceMember.java
@@ -1,0 +1,23 @@
+package org.layer.domain.space.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class SpaceMember {
+
+    private final Long id;
+    private final String avatar;
+
+    private final String name;
+
+    private final Boolean isLeader;
+
+    @QueryProjection
+    public SpaceMember(Long id, String avatar, String name, Boolean isLeader) {
+        this.id = id;
+        this.avatar = avatar;
+        this.name = name;
+        this.isLeader = isLeader;
+    }
+}

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
@@ -1,5 +1,6 @@
 package org.layer.domain.space.repository;
 
+import org.layer.domain.space.dto.SpaceMember;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
 import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.entity.SpaceField;
@@ -20,5 +21,7 @@ public interface SpaceCustomRepository {
     Optional<SpaceWithMemberCount> findByIdAndJoinedMemberId(Long spaceId, Long memberId);
 
     Long updateSpace(Long spaceId, SpaceCategory category, List<SpaceField> fieldList, String name, String introduction, String bannerUrl);
+
+    List<SpaceMember> findAllSpaceMemberBySpaceIdWithIsLeader(Long spaceId);
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
스페이스 팀원 목록 조회하기 API를 추가했어요.
팀장, 스페이스 가입이 빠른순으로 정렬되어 응답합니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="983" alt="스크린샷 2024-08-04 오전 3 21 40" src="https://github.com/user-attachments/assets/810cb7d4-8728-4fbb-935a-ec99717290b5">

### 발생한 쿼리 첨부

```
    select
        m1_0.id,
        m1_0.profile_image_url,
        m1_0.name,
        s1_0.leader_id=m1_0.id 
    from
        member_space_relation msr1_0 
    left join
        member m1_0 
            on msr1_0.member_id=m1_0.id 
    left join
        space s1_0 
            on msr1_0.space_id=s1_0.id 
    where
        msr1_0.space_id=? 
    order by
        msr1_0.created_at
```


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
