### PR TITLE
feat: 회고 수정 및 삭제 로직 구현

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/request/RecommendFormQueryDto.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/request/RecommendFormQueryDto.java
@@ -1,6 +1,7 @@
 package org.layer.domain.form.controller.dto.request;
 
 import org.layer.domain.form.enums.RetrospectPeriod;
+import org.layer.domain.form.enums.RetrospectPeriodic;
 import org.layer.domain.form.enums.RetrospectPurpose;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,8 +10,8 @@ import jakarta.validation.constraints.NotNull;
 @Schema(name = "RecommendFormQueryDto", description = "회고 템플릿 요청 queryParam")
 public record RecommendFormQueryDto(
 	@NotNull
-	@Schema(description = "회고 주기적 여부", example = "true")
-	boolean periodic,
+	@Schema(description = "회고 주기적 여부", example = "REGULAR")
+	RetrospectPeriodic periodic,
 	@Schema(description = "회고가 주기적일 때, 구체적인 주기", example = "WEEKLY")
 	RetrospectPeriod period,
 	@NotNull

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectApi.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectApi.java
@@ -3,8 +3,10 @@ package org.layer.domain.retrospect.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+
 import org.layer.common.annotation.MemberId;
 import org.layer.domain.retrospect.controller.dto.request.RetrospectCreateRequest;
+import org.layer.domain.retrospect.controller.dto.request.RetrospectUpdateRequest;
 import org.layer.domain.retrospect.controller.dto.response.RetrospectCreateResponse;
 import org.layer.domain.retrospect.controller.dto.response.RetrospectListGetResponse;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +16,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "회고", description = "회고 관련 API")
 public interface RetrospectApi {
 
-    @Operation(summary = "회고 생성", description = "회고 생성 이후 생성된 회고의 아이디를 응답합니다.")
-    ResponseEntity<RetrospectCreateResponse> createRetrospect(@PathVariable("spaceId") Long spaceId,
-                                                              @RequestBody @Valid RetrospectCreateRequest request, @MemberId Long memberId);
+	@Operation(summary = "회고 생성", description = "회고 생성 이후 생성된 회고의 아이디를 응답합니다.")
+	ResponseEntity<RetrospectCreateResponse> createRetrospect(@PathVariable("spaceId") Long spaceId,
+		@RequestBody @Valid RetrospectCreateRequest request, @MemberId Long memberId);
 
-    @Operation(summary = "회고 목록 조회", description = "특정 팀 스페이스에서 작성했던 회고 목록을 보는 기능입니다.")
-    ResponseEntity<RetrospectListGetResponse> getRetrospects(@PathVariable("spaceId") Long spaceId, @MemberId Long memberId);
+	@Operation(summary = "회고 목록 조회", description = "특정 팀 스페이스에서 작성했던 회고 목록을 보는 기능입니다.")
+	ResponseEntity<RetrospectListGetResponse> getRetrospects(@PathVariable("spaceId") Long spaceId,
+		@MemberId Long memberId);
+
+	@Operation(summary = "회고 수정", description = "특정 팀 스페이스에서 작성했던 회고를 수정하는 기능입니다.")
+	ResponseEntity<RetrospectListGetResponse> updateRetrospect(@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId, @RequestBody @Valid RetrospectUpdateRequest request, @MemberId Long memberId);
+
+	@Operation(summary = "회고 삭제", description = "특정 팀 스페이스에서 작성했던 회고를 삭제하는 기능입니다.")
+	ResponseEntity<RetrospectListGetResponse> deleteRetrospect(@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId, @MemberId Long memberId);
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
@@ -2,8 +2,10 @@ package org.layer.domain.retrospect.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.layer.common.annotation.MemberId;
 import org.layer.domain.retrospect.controller.dto.request.RetrospectCreateRequest;
+import org.layer.domain.retrospect.controller.dto.request.RetrospectUpdateRequest;
 import org.layer.domain.retrospect.controller.dto.response.RetrospectCreateResponse;
 import org.layer.domain.retrospect.controller.dto.response.RetrospectGetResponse;
 import org.layer.domain.retrospect.controller.dto.response.RetrospectListGetResponse;
@@ -20,36 +22,57 @@ import java.util.List;
 @RequestMapping("/space/{spaceId}/retrospect")
 public class RetrospectController implements RetrospectApi {
 
-    private final RetrospectService retrospectService;
+	private final RetrospectService retrospectService;
 
-    @Override
-    @PostMapping
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<RetrospectCreateResponse> createRetrospect(
-            @PathVariable("spaceId") Long spaceId,
-            @RequestBody @Valid RetrospectCreateRequest request,
-            @MemberId Long memberId) {
+	@Override
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<RetrospectCreateResponse> createRetrospect(
+		@PathVariable("spaceId") Long spaceId,
+		@RequestBody @Valid RetrospectCreateRequest request,
+		@MemberId Long memberId) {
 
-        var newRetrospectId = retrospectService.createRetrospect(request, spaceId, memberId);
+		var newRetrospectId = retrospectService.createRetrospect(request, spaceId, memberId);
 
-        return ResponseEntity.ok().body(RetrospectCreateResponse.of(newRetrospectId));
-    }
+		return ResponseEntity.ok().body(RetrospectCreateResponse.of(newRetrospectId));
+	}
 
-    @Override
-    @GetMapping
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<RetrospectListGetResponse> getRetrospects(@PathVariable("spaceId") Long spaceId,
-                                                                    @MemberId Long memberId) {
+	@Override
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<RetrospectListGetResponse> getRetrospects(@PathVariable("spaceId") Long spaceId,
+		@MemberId Long memberId) {
 
-        RetrospectListGetServiceResponse serviceResponse = retrospectService.getRetrospects(spaceId, memberId);
+		RetrospectListGetServiceResponse serviceResponse = retrospectService.getRetrospects(spaceId, memberId);
 
-        List<RetrospectGetResponse> retrospectGetResponses = serviceResponse.retrospects().stream()
-                .map(r -> RetrospectGetResponse.of(r.retrospectId(), r.title(), r.introduction(), r.isWrite(), r.retrospectStatus(),
-                        r.writeCount(), r.totalCount(), r.createdAt(), r.deadline()))
-                .toList();
+		List<RetrospectGetResponse> retrospectGetResponses = serviceResponse.retrospects().stream()
+			.map(r -> RetrospectGetResponse.of(r.retrospectId(), r.title(), r.introduction(), r.isWrite(),
+				r.retrospectStatus(),
+				r.writeCount(), r.totalCount(), r.createdAt(), r.deadline()))
+			.toList();
 
-        return ResponseEntity.ok()
-                .body(RetrospectListGetResponse.of(serviceResponse.layerCount(), retrospectGetResponses));
-    }
+		return ResponseEntity.ok()
+			.body(RetrospectListGetResponse.of(serviceResponse.layerCount(), retrospectGetResponses));
+	}
+
+	@Override
+	@PatchMapping("/{retrospectId}")
+	public ResponseEntity<RetrospectListGetResponse> updateRetrospect(@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId, @RequestBody @Valid RetrospectUpdateRequest request,
+		@MemberId Long memberId) {
+
+		retrospectService.updateRetrospect(spaceId, retrospectId, request, memberId);
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@DeleteMapping("/{retrospectId}")
+	public ResponseEntity<RetrospectListGetResponse> deleteRetrospect(@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId, @MemberId Long memberId) {
+
+		retrospectService.deleteRetrospect(spaceId, retrospectId, memberId);
+
+		return ResponseEntity.ok().build();
+	}
 
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectUpdateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.layer.domain.retrospect.controller.dto.request;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "RetrospectUpdateRequest", description = "회고 수정 요청 Dto")
+public record RetrospectUpdateRequest(
+	@Schema(description = "회고 제목", example = "수정된 회고 제목입니다.")
+	String title,
+	@Schema(description = "회고 제목", example = "수정된 회고 제목입니다.")
+	String introduction,
+	@Schema(description = "회고 마감 기한", example = "2024-08-04T15:30:00")
+	LocalDateTime deadline
+) {
+}

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -1,6 +1,7 @@
 package org.layer.domain.retrospect.service;
 
 import lombok.RequiredArgsConstructor;
+
 import org.layer.domain.answer.entity.Answers;
 import org.layer.domain.answer.repository.AnswerRepository;
 import org.layer.domain.form.entity.Form;
@@ -12,15 +13,18 @@ import org.layer.domain.question.enums.QuestionType;
 import org.layer.domain.question.repository.QuestionRepository;
 import org.layer.domain.retrospect.controller.dto.request.QuestionCreateRequest;
 import org.layer.domain.retrospect.controller.dto.request.RetrospectCreateRequest;
+import org.layer.domain.retrospect.controller.dto.request.RetrospectUpdateRequest;
 import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.entity.RetrospectStatus;
 import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.layer.domain.retrospect.service.dto.response.RetrospectGetServiceResponse;
 import org.layer.domain.retrospect.service.dto.response.RetrospectListGetServiceResponse;
 import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.entity.Space;
 import org.layer.domain.space.entity.Team;
 import org.layer.domain.space.exception.MemberSpaceRelationException;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
+import org.layer.domain.space.repository.SpaceRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,85 +39,107 @@ import static org.layer.common.exception.MemberSpaceRelationExceptionType.NOT_FO
 @Transactional(readOnly = true)
 public class RetrospectService {
 
-    private final RetrospectRepository retrospectRepository;
-    private final MemberSpaceRelationRepository memberSpaceRelationRepository;
-    private final QuestionRepository questionRepository;
-    private final AnswerRepository answerRepository;
-    private final FormRepository formRepository;
+	private final RetrospectRepository retrospectRepository;
+	private final MemberSpaceRelationRepository memberSpaceRelationRepository;
+	private final QuestionRepository questionRepository;
+	private final AnswerRepository answerRepository;
+	private final FormRepository formRepository;
+	private final SpaceRepository spaceRepository;
 
-    @Transactional
-    public Long createRetrospect(RetrospectCreateRequest request, Long spaceId, Long memberId) {
-        // 해당 스페이스 팀원인지 검증
-        Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
-        team.validateTeamMembership(memberId);
+	@Transactional
+	public Long createRetrospect(RetrospectCreateRequest request, Long spaceId, Long memberId) {
+		// 해당 스페이스 팀원인지 검증
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
+		team.validateTeamMembership(memberId);
 
-        Retrospect retrospect = getRetrospect(request, spaceId);
-        Retrospect savedRetrospect = retrospectRepository.save(retrospect);
+		Retrospect retrospect = getRetrospect(request, spaceId);
+		Retrospect savedRetrospect = retrospectRepository.save(retrospect);
 
-        List<Question> questions = getQuestions(request.questions(), savedRetrospect.getId(), null);
-        questionRepository.saveAll(questions);
+		List<Question> questions = getQuestions(request.questions(), savedRetrospect.getId(), null);
+		questionRepository.saveAll(questions);
 
-        // 새로운 폼 생성(수정)인지 확인
-        if (request.isNewForm()) {
-            // 내 회고 폼에 추가
-            Form baseForm = formRepository.findByIdOrThrow(request.curFormId());
-            Form form = new Form(memberId, spaceId, request.title(), request.introduction(), FormType.CUSTOM, baseForm.getFormTag());
-            Form savedForm = formRepository.save(form);
+		// 새로운 폼 생성(수정)인지 확인
+		if (request.isNewForm()) {
+			// 내 회고 폼에 추가
+			Form baseForm = formRepository.findByIdOrThrow(request.curFormId());
+			Form form = new Form(memberId, spaceId, request.title(), request.introduction(), FormType.CUSTOM,
+				baseForm.getFormTag());
+			Form savedForm = formRepository.save(form);
 
-            List<Question> myQuestions = getQuestions(request.questions(), null, savedForm.getId());
-            questionRepository.saveAll(myQuestions);
-        }
-        return savedRetrospect.getId();
-    }
+			List<Question> myQuestions = getQuestions(request.questions(), null, savedForm.getId());
+			questionRepository.saveAll(myQuestions);
+		}
+		return savedRetrospect.getId();
+	}
 
-    private Retrospect getRetrospect(RetrospectCreateRequest request, Long spaceId) {
-        return Retrospect.builder()
-                .spaceId(spaceId)
-                .title(request.title())
-                .introduction(request.introduction())
-                .retrospectStatus(RetrospectStatus.PROCEEDING)
-                .deadline(request.deadline())
-                .build();
-    }
+	private Retrospect getRetrospect(RetrospectCreateRequest request, Long spaceId) {
+		return Retrospect.builder()
+			.spaceId(spaceId)
+			.title(request.title())
+			.introduction(request.introduction())
+			.retrospectStatus(RetrospectStatus.PROCEEDING)
+			.deadline(request.deadline())
+			.build();
+	}
 
-    public RetrospectListGetServiceResponse getRetrospects(Long spaceId, Long memberId) {
-        // 해당 스페이스 팀원인지 검증
-        Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
-        team.validateTeamMembership(memberId);
+	public RetrospectListGetServiceResponse getRetrospects(Long spaceId, Long memberId) {
+		// 해당 스페이스 팀원인지 검증
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
+		team.validateTeamMembership(memberId);
 
-        List<Retrospect> retrospects = retrospectRepository.findAllBySpaceId(spaceId);
-        List<Long> retrospectIds = retrospects.stream().map(Retrospect::getId).toList();
-        Answers answers = new Answers(answerRepository.findAllByRetrospectIdIn(retrospectIds));
+		List<Retrospect> retrospects = retrospectRepository.findAllBySpaceId(spaceId);
+		List<Long> retrospectIds = retrospects.stream().map(Retrospect::getId).toList();
+		Answers answers = new Answers(answerRepository.findAllByRetrospectIdIn(retrospectIds));
 
-        List<RetrospectGetServiceResponse> retrospectDtos = retrospects.stream()
-                .map(r -> RetrospectGetServiceResponse.of(r.getId(), r.getTitle(), r.getIntroduction(),
-                        answers.hasRetrospectAnswer(memberId, r.getId()), r.getRetrospectStatus(),
-                        answers.getWriteCount(r.getId()), team.getTeamMemberCount(), r.getCreatedAt(), r.getDeadline()))
-                .toList();
+		List<RetrospectGetServiceResponse> retrospectDtos = retrospects.stream()
+			.map(r -> RetrospectGetServiceResponse.of(r.getId(), r.getTitle(), r.getIntroduction(),
+				answers.hasRetrospectAnswer(memberId, r.getId()), r.getRetrospectStatus(),
+				answers.getWriteCount(r.getId()), team.getTeamMemberCount(), r.getCreatedAt(), r.getDeadline()))
+			.toList();
 
-        return RetrospectListGetServiceResponse.of(retrospects.size(), retrospectDtos);
-    }
+		return RetrospectListGetServiceResponse.of(retrospects.size(), retrospectDtos);
+	}
 
-    private void validateTeamMember(Long request, Long memberId) {
-        Optional<MemberSpaceRelation> team = memberSpaceRelationRepository.findBySpaceIdAndMemberId(
-                request, memberId);
-        if (team.isEmpty()) {
-            throw new MemberSpaceRelationException(NOT_FOUND_MEMBER_SPACE_RELATION);
-        }
-    }
+	private List<Question> getQuestions(List<QuestionCreateRequest> questions, Long savedRetrospectId, Long formId) {
+		AtomicInteger index = new AtomicInteger(1);
 
-    private List<Question> getQuestions(List<QuestionCreateRequest> questions, Long savedRetrospectId, Long formId) {
-        AtomicInteger index = new AtomicInteger(1);
+		return questions.stream()
+			.map(question -> Question.builder()
+				.retrospectId(savedRetrospectId)
+				.formId(formId)
+				.content(question.questionContent())
+				.questionOrder(index.getAndIncrement())
+				.questionOwner(QuestionOwner.TEAM)
+				.questionType(QuestionType.stringToEnum(question.questionType()))
+				.build())
+			.toList();
+	}
 
-        return questions.stream()
-                .map(question -> Question.builder()
-                        .retrospectId(savedRetrospectId)
-                        .formId(formId)
-                        .content(question.questionContent())
-                        .questionOrder(index.getAndIncrement())
-                        .questionOwner(QuestionOwner.TEAM)
-                        .questionType(QuestionType.stringToEnum(question.questionType()))
-                        .build())
-                .toList();
-    }
+	@Transactional
+	public void updateRetrospect(Long spaceId, Long retrospectId, RetrospectUpdateRequest request, Long memberId) {
+		// 해당 스페이스 팀원인지 검증
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
+		team.validateTeamMembership(memberId);
+
+		// 팀장인지 검증
+		Space space = spaceRepository.findByIdOrThrow(spaceId);
+		space.isLeaderSpace(memberId);
+
+		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
+		retrospect.updateRetrospect(request.title(), request.introduction(), request.deadline());
+	}
+
+	@Transactional
+	public void deleteRetrospect(Long spaceId, Long retrospectId, Long memberId) {
+		// 해당 스페이스 팀원인지 검증
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
+		team.validateTeamMembership(memberId);
+
+		// 팀장인지 검증
+		Space space = spaceRepository.findByIdOrThrow(spaceId);
+		space.isLeaderSpace(memberId);
+
+		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
+		retrospectRepository.delete(retrospect);
+	}
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.layer.domain.answer.entity.Answers;
 import org.layer.domain.answer.repository.AnswerRepository;
+import org.layer.domain.common.time.Time;
 import org.layer.domain.form.entity.Form;
 import org.layer.domain.form.entity.FormType;
 import org.layer.domain.form.repository.FormRepository;
@@ -45,6 +46,8 @@ public class RetrospectService {
 	private final AnswerRepository answerRepository;
 	private final FormRepository formRepository;
 	private final SpaceRepository spaceRepository;
+
+	private final Time time;
 
 	@Transactional
 	public Long createRetrospect(RetrospectCreateRequest request, Long spaceId, Long memberId) {
@@ -126,7 +129,7 @@ public class RetrospectService {
 		space.isLeaderSpace(memberId);
 
 		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
-		retrospect.updateRetrospect(request.title(), request.introduction(), request.deadline());
+		retrospect.updateRetrospect(request.title(), request.introduction(), request.deadline(), time);
 	}
 
 	@Transactional

--- a/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
@@ -5,12 +5,12 @@ import org.springframework.http.HttpStatus;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public enum RetrospectExceptionType implements ExceptionType{
+public enum RetrospectExceptionType implements ExceptionType {
+	INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "회고 마감기한이 유효하지 않습니다."),
 	DEADLINE_PASSED(HttpStatus.BAD_REQUEST, "회고 마감기한이 지났습니다."),
 	DEADLINE_NOT_PASSED(HttpStatus.BAD_REQUEST, "회고 마감기한이 아직 지나지 않았습니다."),
 	NOT_PROCEEDING_RETROSPECT(HttpStatus.BAD_REQUEST, "진행중인 회고가 아닙니다."),
 	NOT_FOUND_RETROSPECT(HttpStatus.NOT_FOUND, "유효한 회고가 존재하지 않습니다.");
-
 
 	private final HttpStatus status;
 	private final String message;

--- a/layer-domain/src/main/java/org/layer/domain/form/enums/RetrospectPeriodic.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/enums/RetrospectPeriodic.java
@@ -1,0 +1,5 @@
+package org.layer.domain.form.enums;
+
+public enum RetrospectPeriodic {
+	REGULAR, IRREGULAR
+}

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -5,6 +5,7 @@ import static org.layer.common.exception.RetrospectExceptionType.*;
 import java.time.LocalDateTime;
 
 import org.layer.domain.common.BaseTimeEntity;
+import org.layer.domain.common.time.Time;
 import org.layer.domain.retrospect.exception.RetrospectException;
 
 import jakarta.persistence.Entity;
@@ -71,7 +72,11 @@ public class Retrospect extends BaseTimeEntity {
 		}
 	}
 
-	public void updateRetrospect(String title, String introduction, LocalDateTime deadline){
+	public void updateRetrospect(String title, String introduction, LocalDateTime deadline, Time time){
+
+		if(deadline.isAfter(time.now())){
+			throw new RetrospectException(INVALID_DEADLINE);
+		}
 
 		this.title = title;
 		this.introduction = introduction;

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -70,4 +70,11 @@ public class Retrospect extends BaseTimeEntity {
 			throw new RetrospectException(DEADLINE_NOT_PASSED);
 		}
 	}
+
+	public void updateRetrospect(String title, String introduction, LocalDateTime deadline){
+
+		this.title = title;
+		this.introduction = introduction;
+		this.deadline = deadline;
+	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
@@ -60,7 +60,10 @@ public class Space extends BaseEntity {
             throw new SpaceException(SPACE_LEADER_NOT_ALLOW);
         }
         leaderId = memberId;
+    }
 
-
+    public void updateRecentFormId(Long formId, Long memberId){
+        isLeaderSpace(memberId);
+        this.formId = formId;
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고 수정 및 삭제 API 구현했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="692" alt="스크린샷 2024-08-04 오전 5 27 14" src="https://github.com/user-attachments/assets/5aa6bd2a-e9bc-4aeb-a09f-cbed0651a51d">
<img width="648" alt="스크린샷 2024-08-04 오전 5 32 25" src="https://github.com/user-attachments/assets/3ed356d6-3121-4a6d-ac8d-4c88d1e70b57">


### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#117 -> dev
- closed #117 
