### PR TITLE
fix: 스페이스 커스텀 폼 조회 응답에 폼아이디 추가

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/form/controller/dto/response/CustomTemplateResponse.java
@@ -10,6 +10,9 @@ import java.time.LocalDateTime;
 @Schema(name = "DefaultFormGetResponse", description = "커스텀 템플릿 조회 간단 정보 응답 Dto")
 public record CustomTemplateResponse(
         @NotNull
+        @Schema(description = "회고폼 ID", example = "1")
+        Long id,
+        @NotNull
         @Schema(description = "회고폼 이름", example = "Mad Sad Glad 커스텀 템플릿")
         String title,
         @NotNull

--- a/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
+++ b/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
@@ -1,19 +1,9 @@
 package org.layer.domain.form.service;
 
-import static org.layer.common.exception.FormExceptionType.*;
-import static org.layer.domain.form.entity.FormType.*;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-
+import lombok.RequiredArgsConstructor;
 import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
-import org.layer.domain.form.controller.dto.response.CustomTemplateListResponse;
-import org.layer.domain.form.controller.dto.response.CustomTemplateResponse;
-import org.layer.domain.form.controller.dto.response.FormGetResponse;
-import org.layer.domain.form.controller.dto.response.QuestionGetResponse;
-import org.layer.domain.form.controller.dto.response.RecommendFormResponseDto;
+import org.layer.domain.form.controller.dto.response.*;
 import org.layer.domain.form.entity.Form;
 import org.layer.domain.form.exception.FormException;
 import org.layer.domain.form.repository.FormRepository;
@@ -31,7 +21,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.layer.common.exception.FormExceptionType.UNAUTHORIZED_GET_FORM;
+import static org.layer.domain.form.entity.FormType.CUSTOM;
 
 @Service
 @RequiredArgsConstructor
@@ -111,7 +106,7 @@ public class FormService {
 
 		Page<Form> customFormList = formRepository.findAllByFormTypeOrderByIdDesc(pageable, CUSTOM);
 
-		Page<CustomTemplateResponse> customFormResList = customFormList.map(form -> new CustomTemplateResponse(form.getTitle(), form.getFormTag().getTag(), form.getCreatedAt()));
+		Page<CustomTemplateResponse> customFormResList = customFormList.map(form -> new CustomTemplateResponse(form.getId(), form.getTitle(), form.getFormTag().getTag(), form.getCreatedAt()));
 
 		return CustomTemplateListResponse.builder()
 				.customTemplateList(customFormResList)


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="852" alt="스크린샷 2024-08-04 오후 6 50 24" src="https://github.com/user-attachments/assets/a36cc9e2-4804-47f8-9fdb-3849797b7c8e">


### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/125
- closed #125 
