### PR TITLE
fix: 스페이스 커스텀 폼 조회 로직 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
+++ b/layer-api/src/main/java/org/layer/domain/form/service/FormService.java
@@ -1,19 +1,9 @@
 package org.layer.domain.form.service;
 
-import static org.layer.common.exception.FormExceptionType.*;
-import static org.layer.domain.form.entity.FormType.*;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-
+import lombok.RequiredArgsConstructor;
 import org.layer.domain.form.controller.dto.request.FormNameUpdateRequest;
 import org.layer.domain.form.controller.dto.request.RecommendFormQueryDto;
-import org.layer.domain.form.controller.dto.response.CustomTemplateListResponse;
-import org.layer.domain.form.controller.dto.response.CustomTemplateResponse;
-import org.layer.domain.form.controller.dto.response.FormGetResponse;
-import org.layer.domain.form.controller.dto.response.QuestionGetResponse;
-import org.layer.domain.form.controller.dto.response.RecommendFormResponseDto;
+import org.layer.domain.form.controller.dto.response.*;
 import org.layer.domain.form.entity.Form;
 import org.layer.domain.form.exception.FormException;
 import org.layer.domain.form.repository.FormRepository;
@@ -31,7 +21,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.layer.common.exception.FormExceptionType.UNAUTHORIZED_GET_FORM;
+import static org.layer.domain.form.entity.FormType.CUSTOM;
 
 @Service
 @RequiredArgsConstructor
@@ -109,7 +104,7 @@ public class FormService {
 			throw new FormException(UNAUTHORIZED_GET_FORM);
 		}
 
-		Page<Form> customFormList = formRepository.findAllByFormTypeOrderByIdDesc(pageable, CUSTOM);
+		Page<Form> customFormList = formRepository.findAllByFormTypeAndSpaceIdOrderByIdDesc(pageable, CUSTOM, spaceId);
 
 		Page<CustomTemplateResponse> customFormResList = customFormList.map(form -> new CustomTemplateResponse(form.getTitle(), form.getFormTag().getTag(), form.getCreatedAt()));
 

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: application-secret.properties
+    import: optional:file:/config/application-secret.properties
   datasource:
     url: ${DEV_DB_URL}
     username: ${DEV_DB_NAME}

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: optional:file:/config/application-secret.properties
+    import: application-secret.properties
   datasource:
     url: ${DEV_DB_URL}
     username: ${DEV_DB_NAME}

--- a/layer-domain/src/main/java/org/layer/domain/form/repository/FormRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/repository/FormRepository.java
@@ -20,5 +20,6 @@ public interface FormRepository extends JpaRepository<Form, Long> {
 	List<Form> findByFormTypeOrderById(FormType formType);
 
 	Page<Form> findAllByFormTypeOrderByIdDesc(Pageable pageable, FormType formType);
+	Page<Form> findAllByFormTypeAndSpaceIdOrderByIdDesc(Pageable pageable, FormType formType, Long spaceId);
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->

스페이스에 속한 커스텀 폼 리스트를 뽑아오는 API의 응답 값이 좀 이상해서 다시 봤더니,
스페이스에 속한 커스텀 폼을 가져와야하는데, 그냥 모든 커스텀 폼을 가져오고 있었더라고요...
해당 부분을 수정했습니다.

수정 전 FormService.java
```
Page<Form> customFormList = formRepository.findAllByFormTypeOrderByIdDesc(pageable, CUSTOM, spaceId);
```

수정 후 FormService.java
```
Page<Form> customFormList = formRepository.findAllByFormTypeAndSpaceIdOrderByIdDesc(pageable, CUSTOM, spaceId);
```

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="852" alt="스크린샷 2024-08-04 오후 8 11 22" src="https://github.com/user-attachments/assets/09ad0edf-da26-466d-8955-519f8d684ea8">
<img width="854" alt="스크린샷 2024-08-04 오후 8 12 01" src="https://github.com/user-attachments/assets/9e52c25c-74b3-4ebd-aa39-e1db5f06ef0e">

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/127
- closed #127 


