### PR TITLE
fix: 스페이스 삭제시 회고와 액션아이템 삭제

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -199,10 +199,10 @@ public class SpaceService {
         var foundSpace = checkLeaderFromSpace(spaceId, leaderId);
 
         // 액션 아이템 삭제
-        actionItemRepository.removeAllBySpaceId(spaceId);
+        actionItemRepository.deleteAllBySpaceId(spaceId);
 
         // 진행중인 회고 삭제
-        retrospectRepository.removeAllBySpaceId(spaceId);
+        retrospectRepository.deleteAllBySpaceId(spaceId);
 
         memberSpaceRelationRepository.deleteAllBySpaceIdInBatch(foundSpace.getId());
         spaceRepository.delete(foundSpace);

--- a/layer-domain/src/main/java/org/layer/domain/actionItem/repository/ActionItemRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/actionItem/repository/ActionItemRepository.java
@@ -14,11 +14,14 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
 
     List<ActionItem> findAllBySpaceIdAndActionItemStatusOrderByCreatedAtDesc(Long spaceId, ActionItemStatus actionItemStatus);
 
-    default ActionItem findByIdOrThrow(Long actionItemId){
+    default ActionItem findByIdOrThrow(Long actionItemId) {
         return findById(actionItemId)
                 .orElseThrow(() -> new ActionItemException(NOT_FOUND_ACTION_ITEM));
     }
 
     List<ActionItem> findAllByRetrospectId(Long retrospectId);
+
     List<ActionItem> findAllByRetrospectIdIn(List<Long> retrospectId);
+
+    void removeAllBySpaceId(Long spaceId);
 }

--- a/layer-domain/src/main/java/org/layer/domain/actionItem/repository/ActionItemRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/actionItem/repository/ActionItemRepository.java
@@ -4,6 +4,9 @@ import org.layer.domain.actionItem.entity.ActionItem;
 import org.layer.domain.actionItem.enums.ActionItemStatus;
 import org.layer.domain.actionItem.exception.ActionItemException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,5 +26,8 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
 
     List<ActionItem> findAllByRetrospectIdIn(List<Long> retrospectId);
 
-    void removeAllBySpaceId(Long spaceId);
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM ActionItem a WHERE a.spaceId = :spaceId")
+    void deleteAllBySpaceId(Long spaceId);
 }

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/repository/RetrospectRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/repository/RetrospectRepository.java
@@ -3,6 +3,9 @@ package org.layer.domain.retrospect.repository;
 import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.exception.RetrospectException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -13,13 +16,16 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 
     List<Retrospect> findByIdIn(List<Long> ids);
 
-	List<Retrospect> findAllBySpaceIdIn(List<Long> spaceIds);
+    List<Retrospect> findAllBySpaceIdIn(List<Long> spaceIds);
 
     default Retrospect findByIdOrThrow(Long retrospectId) {
         return findById(retrospectId)
                 .orElseThrow(() -> new RetrospectException(NOT_FOUND_RETROSPECT));
     }
 
-    void removeAllBySpaceId(Long spaceId);
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Retrospect r WHERE r.spaceId = :spaceId")
+    void deleteAllBySpaceId(Long spaceId);
 
 }

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/repository/RetrospectRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/repository/RetrospectRepository.java
@@ -9,15 +9,17 @@ import java.util.List;
 import static org.layer.common.exception.RetrospectExceptionType.NOT_FOUND_RETROSPECT;
 
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
-	List<Retrospect> findAllBySpaceId(Long spaceId);
+    List<Retrospect> findAllBySpaceId(Long spaceId);
 
-	List<Retrospect> findByIdIn(List<Long> ids);
+    List<Retrospect> findByIdIn(List<Long> ids);
 
 	List<Retrospect> findAllBySpaceIdIn(List<Long> spaceIds);
 
-	default Retrospect findByIdOrThrow(Long retrospectId){
-		return findById(retrospectId)
-			.orElseThrow(() -> new RetrospectException(NOT_FOUND_RETROSPECT));
-	}
+    default Retrospect findByIdOrThrow(Long retrospectId) {
+        return findById(retrospectId)
+                .orElseThrow(() -> new RetrospectException(NOT_FOUND_RETROSPECT));
+    }
+
+    void removeAllBySpaceId(Long spaceId);
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->

스페이스 삭제시 진행중/완료 회고 삭제와 연계된 액션아이템을 삭제하는 기능을 추가했습니다


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


<img width="778" alt="스크린샷 2024-08-06 오후 11 27 13" src="https://github.com/user-attachments/assets/87f1eff6-a777-4bd5-8e7d-4cfcfcb6ab5e">

<img width="556" alt="스크린샷 2024-08-06 오후 11 25 16" src="https://github.com/user-attachments/assets/b1728c28-eb5c-4cfc-b008-7437d22e5bab">

<img width="735" alt="스크린샷 2024-08-06 오후 11 25 04" src="https://github.com/user-attachments/assets/7dbb995e-d675-4f6e-8a71-35b4649dab1b">
<img width="622" alt="스크린샷 2024-08-06 오후 11 23 35" src="https://github.com/user-attachments/assets/3a10f785-0d99-4655-9a8e-0f6e32919983">
<img width="553" alt="스크린샷 2024-08-06 오후 11 23 17" src="https://github.com/user-attachments/assets/fa2e3528-4736-429d-a11b-91bd12ff553f">
<img width="515" alt="스크린샷 2024-08-06 오후 11 23 10" src="https://github.com/user-attachments/assets/8169c202-1e4c-47d7-9e05-4da4a2302412">


### 발생한 쿼리 첨부
```SQL

Hibernate: 
    select
        s1_0.id,
        s1_0.banner_url,
        s1_0.category,
        s1_0.created_at,
        s1_0.field_list,
        s1_0.form_id,
        s1_0.introduction,
        s1_0.leader_id,
        s1_0.name,
        s1_0.updated_at 
    from
        space s1_0 
    where
        s1_0.id=?
Hibernate: 
    delete 
    from
        action_item ai1_0 
    where
        ai1_0.space_id=?
Hibernate: 
    delete 
    from
        retrospect r1_0 
    where
        r1_0.space_id=?
Hibernate: 
    delete 
    from
        member_space_relation msr1_0 
    where
        msr1_0.space_id=?
Hibernate: 
    select
        s1_0.id,
        s1_0.banner_url,
        s1_0.category,
        s1_0.created_at,
        s1_0.field_list,
        s1_0.form_id,
        s1_0.introduction,
        s1_0.leader_id,
        s1_0.name,
        s1_0.updated_at 
    from
        space s1_0 
    where
        s1_0.id=?
Hibernate: 
    delete 
    from
        space 
    where
        id=?

```

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#130
- closed #130 
