### PR TITLE
fix: 회원 정보 조회 응답 imageUrl 추가

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/auth/controller/AuthApi.java
+++ b/layer-api/src/main/java/org/layer/domain/auth/controller/AuthApi.java
@@ -81,7 +81,8 @@ public interface AuthApi {
                         "memberRole": "USER",
                         "socialId": "123456789",
                         "socialType": "KAKAO",
-                        "accessToken": "[토큰값]"
+                        "accessToken": "[토큰값]",
+                        "imageUrl": null
                     }
                     """
                             )

--- a/layer-api/src/main/java/org/layer/domain/auth/controller/dto/MemberInfoResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/auth/controller/dto/MemberInfoResponse.java
@@ -12,13 +12,15 @@ public record MemberInfoResponse(Long memberId,
                                  String email,
                                  MemberRole memberRole,
                                  String socialId,
-                                 SocialType socialType) {
+                                 SocialType socialType,
+                                 String imageUrl) {
     public static MemberInfoResponse of(Member member) {
         return new MemberInfoResponse(member.getId(),
                 member.getName(),
                 member.getEmail(),
                 member.getMemberRole(),
                 member.getSocialId(),
-                member.getSocialType());
+                member.getSocialType(),
+                member.getProfileImageUrl());
     }
 }

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: application-secret.properties
+    import: optional:file:/config/application-secret.properties
   datasource:
     url: ${DEV_DB_URL}
     username: ${DEV_DB_NAME}

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: optional:file:/config/application-secret.properties
+    import: application-secret.properties
   datasource:
     url: ${DEV_DB_URL}
     username: ${DEV_DB_NAME}


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
GET `/api/auth/member-info` api의 응답값에 회원 프로필 사진 링크를 추가했습니다


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="848" alt="image" src="https://github.com/user-attachments/assets/5b5804bc-e8bf-4a6f-a495-ed89158351c1">


### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #140 
