### PR TITLE
fix: 스페이스 정렬 순서 변경하기

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
@@ -11,6 +11,7 @@ import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.entity.SpaceField;
 import org.layer.domain.space.exception.SpaceException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,7 +49,10 @@ public class SpaceResponse {
             Long memberCount,
 
             @Schema(description = "스페이스 배너 이미지")
-            String bannerUrl
+            String bannerUrl,
+
+            @Schema(description = "스페이스 생성 일자")
+            LocalDateTime createdAt
     ) {
         public static SpaceWithMemberCountInfo toResponse(SpaceWithMemberCount space) {
             return Optional.ofNullable(space)
@@ -61,7 +65,9 @@ public class SpaceResponse {
                             .formId(it.getFormId())
                             .memberCount(it.getMemberCount())
                             .bannerUrl(it.getBannerUrl())
-                            .build())
+                            .createdAt(it.getCreatedAt())
+                            .build()
+                    )
                     .orElseThrow(() -> new BaseCustomException(INVALID_REFRESH_TOKEN));
         }
     }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
@@ -42,7 +42,7 @@ public class SpaceRepositoryImpl implements SpaceCustomRepository {
         return getSpaceWithMemberCountQuery()
                 .where(predicate)
                 .groupBy(space.id)
-                .orderBy(space.id.asc())
+                .orderBy(space.createdAt.desc())
                 .limit(pageSize + 1)
                 .fetch();
     }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 스페이스 조회 시 생성일자 기준으로 내림차순 정렬을 적용했어요.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부
```
Hibernate: 
    select
        s1_0.id,
        s1_0.created_at,
        s1_0.updated_at,
        s1_0.category,
        s1_0.field_list,
        s1_0.name,
        s1_0.introduction,
        s1_0.leader_id,
        s1_0.form_id,
        count(msr2_0.space_id),
        s1_0.banner_url 
    from
        space s1_0 
    left join
        member_space_relation msr1_0 
            on s1_0.id=msr1_0.space_id 
    left join
        member_space_relation msr2_0 
            on s1_0.id=msr2_0.space_id 
    left join
        form f1_0 
            on s1_0.form_id=f1_0.space_id 
    where
        msr1_0.member_id=? 
        and s1_0.id>? 
    group by
        s1_0.id 
    order by
        s1_0.created_at desc 
    limit
        ?

```
## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
