### PR TITLE
feat: 스페이스 단건조회 리더 아이디 반환하기

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
@@ -52,7 +52,10 @@ public class SpaceResponse {
             String bannerUrl,
 
             @Schema(description = "스페이스 생성 일자")
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+
+            @Schema(description = "스페이스 리더 아이디")
+            Long leaderId
     ) {
         public static SpaceWithMemberCountInfo toResponse(SpaceWithMemberCount space) {
             return Optional.ofNullable(space)
@@ -66,6 +69,7 @@ public class SpaceResponse {
                             .memberCount(it.getMemberCount())
                             .bannerUrl(it.getBannerUrl())
                             .createdAt(it.getCreatedAt())
+                            .leaderId(it.getLeaderId())
                             .build()
                     )
                     .orElseThrow(() -> new BaseCustomException(INVALID_REFRESH_TOKEN));


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 스페이스 단건조회 리더 아이디 반환하기

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="1361" alt="image" src="https://github.com/user-attachments/assets/0784e1f6-564a-4942-a919-9452aff8841d">

### 발생한 쿼리 첨부
```
Hibernate: 
    select
        s1_0.id,
        s1_0.created_at,
        s1_0.updated_at,
        s1_0.category,
        s1_0.field_list,
        s1_0.name,
        s1_0.introduction,
        s1_0.leader_id,
        s1_0.form_id,
        count(msr2_0.space_id),
        s1_0.banner_url 
    from
        space s1_0 
    left join
        member_space_relation msr1_0 
            on s1_0.id=msr1_0.space_id 
    left join
        member_space_relation msr2_0 
            on s1_0.id=msr2_0.space_id 
    left join
        form f1_0 
            on s1_0.form_id=f1_0.space_id 
    where
        s1_0.id=? 
        and msr1_0.member_id=?
[2024-08-16 19:04:32:51333] [http-nio-8080-exec-7] INFO  [org.layer.aop.ExecutionLoggingAop.logExecutionTrace:76] - [ExecutionTime] SpaceController.getSpaceById --> 17 (ms)


```

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
