### PR TITLE
feat: 구글 시트 API를 활용한 사용자 설문 CRM 연동하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ layer-domain/src/main/generated
 
 
 log/
+credentials.json
+layer-api/src/main/resources/tokens

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,11 @@ project(":layer-external") {
         implementation project(path: ':layer-common')
         implementation project(path: ':layer-domain')
 
+        implementation 'com.google.api-client:google-api-client:2.0.0'
+        implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
+        implementation 'com.google.apis:google-api-services-sheets:v4-rev20220927-2.0.0'
+
+
         // NCP Object Storage
         implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 

--- a/layer-api/infra/development/docker-compose.yaml
+++ b/layer-api/infra/development/docker-compose.yaml
@@ -9,6 +9,9 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
     volumes:
       - ./application-secret.properties:/config/application-secret.properties
+      - ./log:/log
+      - ./tokens:/config/tokens
+      - ./credentials.json:/config/credentials.json
     networks:
       - app-network
 

--- a/layer-api/src/main/java/org/layer/domain/auth/controller/AuthApi.java
+++ b/layer-api/src/main/java/org/layer/domain/auth/controller/AuthApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.layer.common.annotation.MemberId;
 import org.layer.domain.auth.controller.dto.*;
 import org.springframework.http.ResponseEntity;
@@ -24,18 +25,18 @@ public interface AuthApi {
                             @Header(name = "X-AUTH-TOKEN", description = "소셜 액세스 토큰(Bearer 없이 토큰만)", schema = @Schema(type = "string", format = "jwt"), required = true)
                     },
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="로그인 성공", value = """
-                    {
-                        "memberId": 3,
-                        "name": "김회고",
-                        "email": "kimlayer@kakao.com",
-                        "memberRole": "USER",
-                        "socialId": "123456789",
-                        "socialType": "KAKAO",
-                        "accessToken": "[토큰값]",
-                        "imageUrl": null
-                    }
-                    """
+                            @ExampleObject(name = "로그인 성공", value = """
+                                    {
+                                        "memberId": 3,
+                                        "name": "김회고",
+                                        "email": "kimlayer@kakao.com",
+                                        "memberRole": "USER",
+                                        "socialId": "123456789",
+                                        "socialType": "KAKAO",
+                                        "accessToken": "[토큰값]",
+                                        "imageUrl": null
+                                    }
+                                    """
                             )
                     })),
             @ApiResponse(responseCode = "400", description = "로그인 실패 - 토큰이 유효하지 않음",
@@ -43,12 +44,12 @@ public interface AuthApi {
                             @Header(name = "X-AUTH-TOKEN", description = "소셜 액세스 토큰(Bearer 없이 토큰만)", schema = @Schema(type = "string", format = "jwt"), required = true)
                     },
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="토큰이 유효하지 않음", value = """
-                    {
-                        "name": "FAIL_TO_AUTH",
-                        "message": "인증에 실패했습니다."
-                    }
-                    """
+                            @ExampleObject(name = "토큰이 유효하지 않음", value = """
+                                    {
+                                        "name": "FAIL_TO_AUTH",
+                                        "message": "인증에 실패했습니다."
+                                    }
+                                    """
                             )
                     })),
             @ApiResponse(responseCode = "404", description = "로그인 실패 - 회원이 DB에 없음",
@@ -56,12 +57,12 @@ public interface AuthApi {
                             @Header(name = "X-AUTH_TOKEN", description = "소셜 액세스 토큰(Bearer 없이 토큰만)", schema = @Schema(type = "string", format = "jwt"), required = true)
                     },
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="회원이 DB에 없음", value = """
-                    {
-                        "name": "NOT_FOUND_USER",
-                        "message": "유효한 유저를 찾지 못했습니다."
-                    }
-                    """
+                            @ExampleObject(name = "회원이 DB에 없음", value = """
+                                    {
+                                        "name": "NOT_FOUND_USER",
+                                        "message": "유효한 유저를 찾지 못했습니다."
+                                    }
+                                    """
                             )
                     }))
     })
@@ -74,18 +75,18 @@ public interface AuthApi {
                             @Header(name = "X-AUTH_TOKEN", description = "소셜 액세스 토큰(Bearer 없이 토큰만)", schema = @Schema(type = "string", format = "jwt"), required = true)
                     },
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="회원 가입 성공. 유저의 정보를 리턴", value = """
-                    {
-                        "memberId": 3,
-                        "name": "김회고",
-                        "email": "kimlayer@kakao.com",
-                        "memberRole": "USER",
-                        "socialId": "123456789",
-                        "socialType": "KAKAO",
-                        "accessToken": "[토큰값]",
-                        "imageUrl": null
-                    }
-                    """
+                            @ExampleObject(name = "회원 가입 성공. 유저의 정보를 리턴", value = """
+                                    {
+                                        "memberId": 3,
+                                        "name": "김회고",
+                                        "email": "kimlayer@kakao.com",
+                                        "memberRole": "USER",
+                                        "socialId": "123456789",
+                                        "socialType": "KAKAO",
+                                        "accessToken": "[토큰값]",
+                                        "imageUrl": null
+                                    }
+                                    """
                             )
                     })),
             @ApiResponse(responseCode = "400", description = "회원가입 실패",
@@ -93,19 +94,19 @@ public interface AuthApi {
                             @Header(name = "X-AUTH-TOKEN", description = "소셜 액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
                     },
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="이미 가입된 회원", value = """
-                            {
-                                "name": "NOT_A_NEW_MEMBER",
-                                "message": "이미 가입된 회원입니다."
-                            }
-                    """
+                            @ExampleObject(name = "이미 가입된 회원", value = """
+                                            {
+                                                "name": "NOT_A_NEW_MEMBER",
+                                                "message": "이미 가입된 회원입니다."
+                                            }
+                                    """
                             ),
-                            @ExampleObject(name="토큰이 유효하지 않음", value = """
-                            {
-                                "name": "FAIL_TO_AUTH",
-                                "message": "인증에 실패했습니다."
-                            }
-                            """)
+                            @ExampleObject(name = "토큰이 유효하지 않음", value = """
+                                    {
+                                        "name": "FAIL_TO_AUTH",
+                                        "message": "인증에 실패했습니다."
+                                    }
+                                    """)
                     }))
     })
     public ResponseEntity<SignUpResponse> signUp(@RequestHeader("Authorization") final String socialAccessToken, @RequestBody final SignUpRequest signUpRequest);
@@ -117,18 +118,18 @@ public interface AuthApi {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "토큰 재발급 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="토큰 재발급 성공(리프레시 토큰이 DB에 남아있음, 기한 2주)", value = """
-                    {
-                        "memberId": 4,
-                        "name": "김세정",
-                        "email": "clearrworld@kakao.com",
-                        "memberRole": "USER",
-                        "socialId": "3612007072",
-                        "socialType": "KAKAO",
-                        "accessToken": "[토큰 값]",
-                        "refreshToken": "[토큰 값]"
-                    }
-                    """
+                            @ExampleObject(name = "토큰 재발급 성공(리프레시 토큰이 DB에 남아있음, 기한 2주)", value = """
+                                    {
+                                        "memberId": 4,
+                                        "name": "김세정",
+                                        "email": "clearrworld@kakao.com",
+                                        "memberRole": "USER",
+                                        "socialId": "3612007072",
+                                        "socialType": "KAKAO",
+                                        "accessToken": "[토큰 값]",
+                                        "refreshToken": "[토큰 값]"
+                                    }
+                                    """
                             )
                     })),
             @ApiResponse(responseCode = "401", description = "토큰 재발급 실패",
@@ -136,19 +137,19 @@ public interface AuthApi {
                             @Header(name = "Refresh", description = "자체 refresh token", schema = @Schema(type = "string", format = "jwt"), required = true)
                     },
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name="토큰 재발급 실패(리프레시 토큰이 DB에 없음)", value = """
-                    {
-                      "name": "NOT_FOUND_USER",
-                      "message": "유효한 유저를 찾지 못했습니다."
-                    }
-                    """
+                            @ExampleObject(name = "토큰 재발급 실패(리프레시 토큰이 DB에 없음)", value = """
+                                    {
+                                      "name": "NOT_FOUND_USER",
+                                      "message": "유효한 유저를 찾지 못했습니다."
+                                    }
+                                    """
                             ),
-                    @ExampleObject(name="토큰 재발급 실패(잘못된 리프레시 토큰)", value = """
-                    {
-                        "name": "INVALID_REFRESH_TOKEN",
-                        "message": "refresh token이 유효하지 않습니다."
-                    }
-                    """
+                            @ExampleObject(name = "토큰 재발급 실패(잘못된 리프레시 토큰)", value = """
+                                    {
+                                        "name": "INVALID_REFRESH_TOKEN",
+                                        "message": "refresh token이 유효하지 않습니다."
+                                    }
+                                    """
                             )
                     }))
     })
@@ -161,22 +162,22 @@ public interface AuthApi {
             headers = {
                     @Header(name = "Authorization", description = "자체 jwt 액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
             })
-    public ResponseEntity<?> withdraw(WithdrawMemberRequest withdrawMemberRequest);
+    public ResponseEntity<?> withdraw(@MemberId Long memberId, @Valid @RequestBody WithdrawMemberRequest withdrawMemberRequest);
 
     @Operation(summary = "회원 정보 얻기", description = "header Authorization에 Bearer [액세스토큰]을 넣어 인증하면 회원 정보를 얻을 수 있습니다.")
     @ApiResponse(responseCode = "200", description = "회원 정보 얻기 성공",
             content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name="회원 정보 얻기 성공", value = """
-                    {
-                        "memberId": 3,
-                        "name": "김회고",
-                        "email": "kimlayer@kakao.com",
-                        "memberRole": "USER",
-                        "socialId": "123456789",
-                        "socialType": "KAKAO",
-                        "imageUrl": null
-                    }
-                    """)}))
+                    @ExampleObject(name = "회원 정보 얻기 성공", value = """
+                            {
+                                "memberId": 3,
+                                "name": "김회고",
+                                "email": "kimlayer@kakao.com",
+                                "memberRole": "USER",
+                                "socialId": "123456789",
+                                "socialType": "KAKAO",
+                                "imageUrl": null
+                            }
+                            """)}))
     public MemberInfoResponse getMemberInfo(@MemberId Long memberId);
 
     // TODO: 토큰 확인용 임시 API 추후 삭제

--- a/layer-api/src/main/java/org/layer/domain/auth/controller/AuthController.java
+++ b/layer-api/src/main/java/org/layer/domain/auth/controller/AuthController.java
@@ -51,8 +51,8 @@ public class AuthController implements AuthApi {
 
     // 회원 탈퇴
     @PostMapping("/withdraw")
-    public ResponseEntity<?> withdraw(WithdrawMemberRequest withdrawMemberRequest) {
-        authService.withdraw(withdrawMemberRequest.memberId());
+    public ResponseEntity<?> withdraw(@MemberId Long memberId, WithdrawMemberRequest withdrawMemberRequest) {
+        authService.withdraw(memberId, withdrawMemberRequest);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -64,6 +64,7 @@ public class AuthController implements AuthApi {
                 ReissueTokenResponse.of(authService.reissueToken(refreshToken, reissueTokenRequest.memberId())),
                 HttpStatus.CREATED);
     }
+
 
     // 액세스 토큰으로 회원 정보 얻기
     @GetMapping("/member-info")

--- a/layer-api/src/main/java/org/layer/domain/member/controller/MemberApi.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/MemberApi.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.layer.common.annotation.MemberId;
-import org.layer.domain.form.controller.dto.response.FormGetResponse;
+import org.layer.domain.member.controller.dto.CreateFeedbackRequest;
 import org.layer.domain.member.controller.dto.UpdateMemberInfoRequest;
 import org.layer.domain.member.controller.dto.UpdateMemberInfoResponse;
 import org.springframework.http.ResponseEntity;
@@ -13,5 +13,8 @@ import org.springframework.http.ResponseEntity;
 public interface MemberApi {
     @Operation(summary = "회원 정보(이름, 프로필 사진) 수정", method = "POST", description = "회원의 이름과 프로필 사진(url)을 수정합니다.")
     ResponseEntity<UpdateMemberInfoResponse> updateMemberInfo(@MemberId Long memberId, @Valid UpdateMemberInfoRequest updateMemberInfoRequest);
+
+    @Operation(summary = "서비스 사용에 대한 피드백 남기기", method = "POST")
+    ResponseEntity<Void> createFeedback(@MemberId Long memberId, @Valid CreateFeedbackRequest createFeedbackRequest);
 
 }

--- a/layer-api/src/main/java/org/layer/domain/member/controller/MemberController.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package org.layer.domain.member.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.layer.common.annotation.MemberId;
+import org.layer.domain.member.controller.dto.CreateFeedbackRequest;
 import org.layer.domain.member.controller.dto.UpdateMemberInfoRequest;
 import org.layer.domain.member.controller.dto.UpdateMemberInfoResponse;
 import org.layer.domain.member.service.MemberService;
@@ -22,5 +23,12 @@ public class MemberController implements MemberApi {
         UpdateMemberInfoResponse response = memberService.updateMemberInfo(memberId, updateMemberInfoRequest);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @Override
+    @PostMapping("/feedback")
+    public ResponseEntity<Void> createFeedback(@MemberId Long memberId, @Valid @RequestBody CreateFeedbackRequest createFeedbackRequest) {
+        memberService.createFeedback(memberId, createFeedbackRequest);
+        return null;
     }
 }

--- a/layer-api/src/main/java/org/layer/domain/member/controller/dto/CreateFeedbackRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/dto/CreateFeedbackRequest.java
@@ -1,0 +1,15 @@
+package org.layer.domain.member.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "피드백 남기기 요청 DTO")
+public record CreateFeedbackRequest(
+        @Schema(title = "서비스 만족도 1 - 5")
+        int satisfaction,
+
+        @Schema(title = "자세한 피드백 정보")
+        String description
+) {
+}

--- a/layer-api/src/main/java/org/layer/domain/member/controller/dto/WithrawMemberRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/member/controller/dto/WithrawMemberRequest.java
@@ -1,4 +1,4 @@
-package org.layer.domain.auth.controller.dto;
+package org.layer.domain.member.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -7,7 +7,7 @@ import lombok.Builder;
 
 @Builder
 @Schema(description = "회원 탈퇴하기 요청 DTO")
-public record WithdrawMemberRequest(
+public record WithrawMemberRequest(
         @NotNull
         @Size(min = 3, max = 3)
         @Schema(title = "삭제 이유 체크박스")

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -46,6 +46,8 @@ google:
     client_secret: ${DEV_GOOGLE_CLIENT_SECRET}
     redirect_uri: ${DEV_GOOGLE_REDIRECT_URI}
     code_redirect_uri: http://localhost:8080/api/auth/oauth2/google/code
+  sheet:
+    id: ${GOOGLE_SHEET_ID}
 
 
 webmvc:

--- a/layer-api/src/main/resources/application-local.yml
+++ b/layer-api/src/main/resources/application-local.yml
@@ -51,6 +51,9 @@ google:
     client_secret: ${DEV_GOOGLE_CLIENT_SECRET}
     redirect_uri: ${DEV_GOOGLE_REDIRECT_URI}
     code_redirect_uri: http://localhost:8080/api/auth/oauth2/google/code
+  sheet:
+    id: ${GOOGLE_SHEET_ID}
+
 
 
 webmvc:

--- a/layer-api/src/main/resources/application-prod.yml
+++ b/layer-api/src/main/resources/application-prod.yml
@@ -46,6 +46,8 @@ google:
     client_secret: ${DEV_GOOGLE_CLIENT_SECRET}
     redirect_uri: ${DEV_GOOGLE_REDIRECT_URI}
     code_redirect_uri: http://localhost:8080/api/auth/oauth2/google/code
+  sheet:
+    id: ${GOOGLE_SHEET_ID}
 
 
 webmvc:

--- a/layer-api/src/main/resources/application-test.yml
+++ b/layer-api/src/main/resources/application-test.yml
@@ -50,6 +50,8 @@ google:
     client_secret: ${DEV_GOOGLE_CLIENT_SECRET}
     redirect_uri: ${DEV_GOOGLE_REDIRECT_URI}
     code_redirect_uri: http://localhost:8080/api/auth/oauth2/google/code
+  sheet:
+    id: ${GOOGLE_SHEET_ID}
 
 
 webmvc:

--- a/layer-api/src/test/java/org/layer/domain/retrospect/service/RetrospectServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/retrospect/service/RetrospectServiceTest.java
@@ -1,9 +1,5 @@
 package org.layer.domain.retrospect.service;
 
-import static org.layer.domain.space.entity.SpaceField.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,55 +22,60 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.layer.domain.space.entity.SpaceField.DEVELOPMENT;
+
 @SpringBootTest
 @ActiveProfiles("test")
 public class RetrospectServiceTest {
 
-	@Autowired
-	private RetrospectService retrospectService;
+    @Autowired
+    private RetrospectService retrospectService;
 
-	@Autowired
-	private RetrospectRepository retrospectRepository;
+    @Autowired
+    private RetrospectRepository retrospectRepository;
 
-	@Autowired
-	private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-	@Autowired
-	private SpaceRepository spaceRepository;
+    @Autowired
+    private SpaceRepository spaceRepository;
 
-	@Autowired
-	private MemberSpaceRelationRepository memberSpaceRelationRepository;
+    @Autowired
+    private MemberSpaceRelationRepository memberSpaceRelationRepository;
 
-	@Test
-	void 정상입력의_경우_회고생성에_성공한다() {
-		// given
-		// TODO : 이 부분은 이렇게 처리할지 or data.sql로 처리할지 고민.
-		Member member = Member.builder()
-			.name("홍길동")
-			.email("qwer@naver.com")
-			.memberRole(MemberRole.USER)
-			.socialType(SocialType.GOOGLE)
-			.socialId("123456789")
-			.build();
-		Member member1 = memberRepository.saveAndFlush(member);
+    @Test
+    void 정상입력의_경우_회고생성에_성공한다() {
+        // given
+        // TODO : 이 부분은 이렇게 처리할지 or data.sql로 처리할지 고민.
+        Member member = Member.builder()
+                .name("홍길동")
+                .email("qwer@naver.com")
+                .memberRole(MemberRole.USER)
+                .socialType(SocialType.GOOGLE)
+                .socialId("123456789")
+                .build();
+        Member member1 = memberRepository.saveAndFlush(member);
 
-		Space space = new Space(null, SpaceCategory.TEAM, List.of(DEVELOPMENT), "회고스페이스이름입니다", "회고스페이스 설명입니다", 1L, 1L);
-		spaceRepository.saveAndFlush(space);
-		memberSpaceRelationRepository.saveAndFlush(new MemberSpaceRelation(member1.getId(), space));
+        Space space = new Space(null, SpaceCategory.TEAM, List.of(DEVELOPMENT), "회고스페이스이름입니다", "회고스페이스 설명입니다", 1L, 1L);
+        spaceRepository.saveAndFlush(space);
+        memberSpaceRelationRepository.saveAndFlush(new MemberSpaceRelation(member1.getId(), space));
 
-		RetrospectCreateRequest request = new RetrospectCreateRequest("회고제목입니다", "회고소개입니다",
-			List.of(new QuestionCreateRequest("질문1", QuestionType.PLAIN_TEXT.getStyle()),
-				new QuestionCreateRequest("질문2", QuestionType.PLAIN_TEXT.getStyle()),
-				new QuestionCreateRequest("질문3", QuestionType.PLAIN_TEXT.getStyle())),
-			LocalDateTime.of(2024, 8, 4, 3, 5),
-			false, null, null, null);
-		// when
-		Long savedId = retrospectService.createRetrospect(request, 1L, 1L);
+        RetrospectCreateRequest request = new RetrospectCreateRequest("회고제목입니다", "회고소개입니다",
+                List.of(new QuestionCreateRequest("질문1", QuestionType.PLAIN_TEXT.getStyle()),
+                        new QuestionCreateRequest("질문2", QuestionType.PLAIN_TEXT.getStyle()),
+                        new QuestionCreateRequest("질문3", QuestionType.PLAIN_TEXT.getStyle())),
+                LocalDateTime.of(2024, 8, 4, 3, 5),
+                false, null, null, null);
+        // when
+        Long savedId = retrospectService.createRetrospect(request, 1L, 1L);
 
-		// then
-		Retrospect retrospect = retrospectRepository.findByIdOrThrow(savedId);
-		Assertions.assertThat(retrospect)
-			.extracting("title", "introduction", "retrospectStatus")
-			.containsExactly("회고제목입니다", "회고소개입니다", RetrospectStatus.PROCEEDING);
-	}
+        // then
+        Retrospect retrospect = retrospectRepository.findByIdOrThrow(savedId);
+        Assertions.assertThat(retrospect)
+                .extracting("title", "introduction", "retrospectStatus")
+                .containsExactly("회고제목입니다", "회고소개입니다", RetrospectStatus.PROCEEDING);
+    }
 }

--- a/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
@@ -6,11 +6,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.layer.domain.common.BaseTimeEntity;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,7 +37,7 @@ public class Member {
 
 
     @Builder(access = AccessLevel.PUBLIC)
-    private Member(String name,String email, MemberRole memberRole,
+    private Member(String name, String email, MemberRole memberRole,
                    SocialType socialType, String socialId) {
         this.name = name;
         this.email = email;

--- a/layer-domain/src/main/java/org/layer/domain/member/entity/MemberFeedback.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/entity/MemberFeedback.java
@@ -1,0 +1,32 @@
+package org.layer.domain.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class MemberFeedback {
+
+    private Long memberId;
+    private String memberName;
+    private String email;
+    private LocalDateTime memberCreatedAt;
+    private Long retrospectCount;
+    private Long spaceCount;
+
+    @Override
+    public String toString() {
+        return "MemberDataDto{" +
+                "memberId=" + memberId +
+                ", memberName='" + memberName + '\'' +
+                ", email='" + email + '\'' +
+                ", memberCreatedAt=" + memberCreatedAt +
+                ", retrospectCount=" + retrospectCount +
+                ", spaceCount=" + spaceCount +
+                '}';
+    }
+}

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberCustomRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberCustomRepository.java
@@ -1,0 +1,11 @@
+package org.layer.domain.member.repository;
+
+import org.layer.domain.member.entity.MemberFeedback;
+
+import java.util.Optional;
+
+
+public interface MemberCustomRepository {
+
+    Optional<MemberFeedback> findAllMemberFeedback(Long memberId);
+}

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 import static org.layer.common.exception.MemberExceptionType.NOT_FOUND_USER;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
     Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 
     default Member findByIdOrThrow(Long memberId) {

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,47 @@
+package org.layer.domain.member.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.layer.domain.member.entity.MemberFeedback;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static org.layer.domain.answer.entity.QAnswer.answer;
+import static org.layer.domain.member.entity.QMember.member;
+import static org.layer.domain.space.entity.QMemberSpaceRelation.memberSpaceRelation;
+import static org.layer.domain.space.entity.QSpace.space;
+
+@Repository
+public class MemberRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemberRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Optional<MemberFeedback> findAllMemberFeedback(Long memberId) {
+
+        return Optional.ofNullable(queryFactory
+                .select(
+                        Projections.constructor(MemberFeedback.class,
+                                member.id.as("memberId"),
+                                member.name.as("memberName"),
+                                member.email.as("email"),
+                                member.createdAt.as("memberCreatedAt"),
+                                answer.retrospectId.countDistinct().as("retrospectCount"),
+                                space.id.countDistinct().as("spaceCount")
+                        )
+                )
+                .from(member)
+                .join(memberSpaceRelation).on(member.id.eq(memberSpaceRelation.memberId))
+                .leftJoin(space).on(space.id.eq(memberSpaceRelation.space.id))
+                .leftJoin(answer).on(answer.memberId.eq(member.id))
+                .where(member.id.eq(memberId))
+                .groupBy(member.id)
+                .fetchOne());
+    }
+}

--- a/layer-external/src/main/java/org/layer/external/google/config/GoogleConfig.java
+++ b/layer-external/src/main/java/org/layer/external/google/config/GoogleConfig.java
@@ -1,0 +1,76 @@
+package org.layer.external.google.config;
+
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.SheetsScopes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.layer.external.google.service.GoogleApiService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+@Slf4j
+@RequiredArgsConstructor
+public class GoogleConfig {
+
+    private final String APPLICATION_NAME = "Google Sheets API Java Quickstart";
+    private final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+
+    private final List<String> SCOPES = Collections.singletonList(SheetsScopes.SPREADSHEETS);
+
+    private final ResourceLoader resourceLoader;
+
+    @Bean
+    public Sheets getGoogleSheetService() throws GeneralSecurityException, IOException {
+        final NetHttpTransport HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
+
+        return new Sheets.Builder(HTTP_TRANSPORT, JSON_FACTORY, getCredentials(HTTP_TRANSPORT))
+                .setApplicationName(APPLICATION_NAME)
+                .build();
+    }
+
+
+    private Credential getCredentials(final NetHttpTransport HTTP_TRANSPORT) throws IOException {
+        String CREDENTIALS_FILE_PATH = "/credentials.json";
+
+
+        InputStream in = GoogleApiService.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
+
+        if (in == null) {
+            throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
+        }
+
+        GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
+        Resource resource = resourceLoader.getResource("classpath:tokens");
+
+
+        GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
+                HTTP_TRANSPORT, JSON_FACTORY, clientSecrets, SCOPES)
+                .setDataStoreFactory(new FileDataStoreFactory(resource.getFile()))
+                .setAccessType("offline")
+                .build();
+        LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
+    }
+}

--- a/layer-external/src/main/java/org/layer/external/google/enums/SheetType.java
+++ b/layer-external/src/main/java/org/layer/external/google/enums/SheetType.java
@@ -1,0 +1,17 @@
+package org.layer.external.google.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SheetType {
+
+    FEEDBACK("feedback", "A:H"),
+    WITHDRAW("withdraw", "A:H");
+
+    private String sheetName;
+    private String Columns;
+
+
+}

--- a/layer-external/src/main/java/org/layer/external/google/service/GoogleApiService.java
+++ b/layer-external/src/main/java/org/layer/external/google/service/GoogleApiService.java
@@ -1,0 +1,62 @@
+package org.layer.external.google.service;
+
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.layer.domain.member.entity.MemberFeedback;
+import org.layer.external.google.enums.SheetType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GoogleApiService {
+    private final Sheets googleSheetService;
+
+    @Value("${google.sheet.id}")
+    private String sheetId;
+
+
+    public void writeFeedback(SheetType sheetType, MemberFeedback memberFeedback, int score, String description) {
+        new MemberFeedback();
+        try {
+            String feedbackSheet = sheetType.getSheetName() + "!" + sheetType.getColumns();
+            ValueRange response = googleSheetService.spreadsheets().values().get(sheetId, feedbackSheet).execute();
+
+            List<List<Object>> existingValues = response.getValues();
+            int currentRowCount = existingValues != null ? existingValues.size() : 0;
+
+            // 다음 행에서 데이터를 시작하도록 설정
+            String range = sheetType.getSheetName() + "!A" + (currentRowCount + 1) + ":H" + (currentRowCount + 1);
+            List<List<Object>> values = new ArrayList<>();
+            List<Object> row = new ArrayList<>();
+
+            row.add(memberFeedback.getMemberId() != null ? memberFeedback.getMemberId() : "");
+            row.add(Optional.ofNullable(memberFeedback.getEmail()).orElse(""));
+            row.add(Optional.ofNullable(memberFeedback.getMemberName()).orElse(""));
+            row.add(memberFeedback.getMemberCreatedAt() != null ? memberFeedback.getMemberCreatedAt().toString() : "");
+            row.add(memberFeedback.getRetrospectCount() != null ? memberFeedback.getRetrospectCount() : "");
+            row.add(memberFeedback.getSpaceCount() != null ? memberFeedback.getSpaceCount() : "");
+            row.add(score != 0 ? score : "");
+            row.add(Optional.ofNullable(description).orElse(""));
+
+
+            values.add(row);
+            ValueRange body = new ValueRange().setValues(values);
+            googleSheetService.spreadsheets().values().update(sheetId, range, body)
+                    .setValueInputOption("RAW")
+                    .execute();
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 사용성 피드백 정보, 회원탈퇴 인사이트 작성 시 구글 시트에 행이 추가됩니다.
- 각 카테고리는 Sheet를 기준으로 저장됩니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/user-attachments/assets/448e036c-2c97-408a-ae93-f798452f41cd)

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #151 
