### PR TITLE
feat: 기본 템플릿 조회 시 목적 태그 목록 응답하기

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/template/controller/dto/TemplateDetailInfoResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/template/controller/dto/TemplateDetailInfoResponse.java
@@ -35,10 +35,13 @@ public record TemplateDetailInfoResponse(
 
         @Schema(description = "템플릿 질문과 그 설명 리스트")
         @NotNull
-        List<TemplateDetailQuestionResponse> templateDetailQuestionList // 질문(회고 과정)에 대한 설명
+        List<TemplateDetailQuestionResponse> templateDetailQuestionList, // 질문(회고 과정)에 대한 설명
+
+        @Schema(description = "템플릿 목적 태그 리스트")
+        List<TemplatePurposeResponse> templatePurposeResponseList // 질문(회고 과정)에 대한 설명
 
 ) {
-    public static TemplateDetailInfoResponse toResponse(Form form, TemplateMetadata templateMetadata, List<TemplateDetailQuestionResponse> templateQuestionList) {
+    public static TemplateDetailInfoResponse toResponse(Form form, TemplateMetadata templateMetadata, List<TemplateDetailQuestionResponse> templateQuestionList, List<TemplatePurposeResponse> templatePurposeResponseList) {
         return TemplateDetailInfoResponse.builder()
                 .id(form.getId())
                 .title(form.getTitle())
@@ -48,6 +51,7 @@ public record TemplateDetailInfoResponse(
                 .tipTitle(templateMetadata.getTipTitle())
                 .tipDescription(templateMetadata.getTipDescription())
                 .templateDetailQuestionList(templateQuestionList)
+                .templatePurposeResponseList(templatePurposeResponseList)
                 .build();
     }
 }

--- a/layer-api/src/main/java/org/layer/domain/template/controller/dto/TemplatePurposeResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/template/controller/dto/TemplatePurposeResponse.java
@@ -1,0 +1,24 @@
+package org.layer.domain.template.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import org.layer.domain.template.entity.TemplatePurpose;
+
+@Builder
+@Schema(description = "템플릿 목적 응답 ")
+public record TemplatePurposeResponse(
+        @Schema(description = "기본 ID")
+        @NotNull
+        Long id,
+        @Schema(description = "템플릿 목적", example = "빠르고 효율적인 회고")
+        @NotNull
+        String purpose
+) {
+    public static TemplatePurposeResponse toResponse(TemplatePurpose purpose) {
+        return TemplatePurposeResponse.builder()
+                .id(purpose.getId())
+                .purpose(purpose.getPurpose())
+                .build();
+    }
+}

--- a/layer-api/src/main/java/org/layer/domain/template/service/TemplateService.java
+++ b/layer-api/src/main/java/org/layer/domain/template/service/TemplateService.java
@@ -8,11 +8,14 @@ import org.layer.domain.question.entity.Question;
 import org.layer.domain.question.repository.QuestionRepository;
 import org.layer.domain.template.controller.dto.TemplateDetailInfoResponse;
 import org.layer.domain.template.controller.dto.TemplateDetailQuestionResponse;
+import org.layer.domain.template.controller.dto.TemplatePurposeResponse;
 import org.layer.domain.template.controller.dto.TemplateSimpleInfoResponse;
 import org.layer.domain.template.entity.QuestionDescription;
 import org.layer.domain.template.entity.TemplateMetadata;
+import org.layer.domain.template.entity.TemplatePurpose;
 import org.layer.domain.template.repository.QuestionDescriptionRepository;
 import org.layer.domain.template.repository.TemplateMetadataRepository;
+import org.layer.domain.template.repository.TemplatePurposeRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,6 +30,7 @@ public class TemplateService {
     private final TemplateMetadataRepository templateMetadataRepository;
     private final QuestionRepository questionRepository;
     private final QuestionDescriptionRepository questionDescriptionRepository;
+    private final TemplatePurposeRepository templatePurposeRepository;
 
     //== 간단 정보 단건 조회 ==//
     public TemplateSimpleInfoResponse getTemplateSimpleInfo(Long formId) {
@@ -41,7 +45,9 @@ public class TemplateService {
         TemplateMetadata template = templateMetadataRepository.findByFormIdOrThrow(formId);
         List<Question> questionList = questionRepository.findAllByFormId(formId);
 
+        List<TemplatePurpose> templatePurposeList = templatePurposeRepository.findAllByFormId(formId);
 
+        List<TemplatePurposeResponse> templatePurposeResponses = templatePurposeList.stream().map(TemplatePurposeResponse::toResponse).toList();
         List<TemplateDetailQuestionResponse> questionDesList = questionList.stream().map(q -> {
             QuestionDescription description = questionDescriptionRepository.findByQuestionIdOrThrow(q.getId());
             return TemplateDetailQuestionResponse.builder()
@@ -50,7 +56,7 @@ public class TemplateService {
                     .description(description.getDescription()).build();
         }).toList();
 
-        return TemplateDetailInfoResponse.toResponse(form, template, questionDesList);
+        return TemplateDetailInfoResponse.toResponse(form, template, questionDesList, templatePurposeResponses);
     }
 
 

--- a/layer-domain/src/main/java/org/layer/domain/template/entity/TemplatePurpose.java
+++ b/layer-domain/src/main/java/org/layer/domain/template/entity/TemplatePurpose.java
@@ -4,8 +4,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class TemplatePurpose {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/layer-domain/src/main/java/org/layer/domain/template/repository/TemplatePurposeRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/template/repository/TemplatePurposeRepository.java
@@ -3,5 +3,9 @@ package org.layer.domain.template.repository;
 import org.layer.domain.template.entity.TemplatePurpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TemplatePurposeRepository extends JpaRepository<TemplatePurpose, Long> {
+
+    List<TemplatePurpose> findAllByFormId(Long formId);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 기본 템플릿 조회 시 목적 태그(TemplatePurpose) 목록 응답하기

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="1141" alt="스크린샷 2024-08-17 오후 5 36 22" src="https://github.com/user-attachments/assets/b26d0711-fd8d-43b2-989a-0187aa6250c2">

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #153 
