### PR TITLE
fix: 스페이스 떠나기 팀장확인 로직 변경

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -24,8 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.layer.common.exception.MemberSpaceRelationExceptionType.NOT_FOUND_MEMBER_SPACE_RELATION;
-import static org.layer.common.exception.SpaceExceptionType.NOT_FOUND_SPACE;
-import static org.layer.common.exception.SpaceExceptionType.SPACE_ALREADY_JOINED;
+import static org.layer.common.exception.SpaceExceptionType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -122,7 +121,10 @@ public class SpaceService {
         /*
           스페이스 팀장 여부 확인
          */
-        foundSpace.isLeaderSpace(memberId);
+        if (foundSpace.getLeaderId().equals(memberId)) {
+            throw new SpaceException(SPACE_LEADER_CANNOT_LEAVE);
+        }
+
 
         /*
           개인 스페이스의 경우, 이탈 시 Space 엔티티의 로직이 된다.


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 스페이스 떠니기 API에 팀장이 아닐경우 throw하던 로직을 팀장일 경우로 변경했어요.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
