### PR TITLE
fix: 스페이스 조회시 리더 정보 응답하기 #157

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import org.layer.common.dto.Meta;
 import org.layer.common.exception.BaseCustomException;
+import org.layer.domain.space.dto.Leader;
 import org.layer.domain.space.dto.SpaceMember;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
 import org.layer.domain.space.entity.SpaceCategory;
@@ -55,7 +56,7 @@ public class SpaceResponse {
             LocalDateTime createdAt,
 
             @Schema(description = "스페이스 리더 아이디")
-            Long leaderId
+            Leader leader
     ) {
         public static SpaceWithMemberCountInfo toResponse(SpaceWithMemberCount space) {
             return Optional.ofNullable(space)
@@ -69,7 +70,7 @@ public class SpaceResponse {
                             .memberCount(it.getMemberCount())
                             .bannerUrl(it.getBannerUrl())
                             .createdAt(it.getCreatedAt())
-                            .leaderId(it.getLeaderId())
+                            .leader(space.getLeader())
                             .build()
                     )
                     .orElseThrow(() -> new BaseCustomException(INVALID_REFRESH_TOKEN));

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/Leader.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/Leader.java
@@ -1,0 +1,11 @@
+package org.layer.domain.space.dto;
+
+
+import lombok.Builder;
+
+@Builder
+public record Leader(
+        Long id,
+        String name
+) {
+}

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithMemberCount.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithMemberCount.java
@@ -4,6 +4,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import org.layer.domain.member.entity.Member;
 import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.entity.SpaceField;
 
@@ -26,14 +27,14 @@ public class SpaceWithMemberCount {
     private String name;
     private String introduction;
     @NotNull
-    private Long leaderId;
+    private Leader leader;
     private Long formId;
     private Long memberCount;
 
     private String bannerUrl;
 
     @QueryProjection
-    public SpaceWithMemberCount(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, SpaceCategory category, List<SpaceField> fieldList, String name, String introduction, Long leaderId, Long formId, Long memberCount, String bannerUrl) {
+    public SpaceWithMemberCount(Long id, LocalDateTime createdAt, LocalDateTime updatedAt, SpaceCategory category, List<SpaceField> fieldList, String name, String introduction, Member leader, Long formId, Long memberCount, String bannerUrl) {
         this.id = id;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -41,7 +42,7 @@ public class SpaceWithMemberCount {
         this.fieldList = fieldList;
         this.name = name;
         this.introduction = introduction;
-        this.leaderId = leaderId;
+        this.leader = Leader.builder().id(leader.getId()).name(leader.getName()).build();
         this.formId = formId;
         this.memberCount = memberCount;
         this.bannerUrl = bannerUrl;


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 스페이스 조회 시 리더 정보를 포함하여 응답합니다

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/1689c423-cf41-4232-bda0-e05d1faeb93a">

### 발생한 쿼리 첨부
```
Hibernate: 
    select
        s1_0.id,
        s1_0.created_at,
        s1_0.updated_at,
        s1_0.category,
        s1_0.field_list,
        s1_0.name,
        s1_0.introduction,
        m1_0.id,
        m1_0.created_at,
        m1_0.email,
        m1_0.member_role,
        m1_0.name,
        m1_0.profile_image_url,
        m1_0.social_id,
        m1_0.social_type,
        m1_0.updated_at,
        s1_0.form_id,
        count(msr2_0.space_id),
        s1_0.banner_url 
    from
        space s1_0 
    left join
        member_space_relation msr1_0 
            on s1_0.id=msr1_0.space_id 
    left join
        member_space_relation msr2_0 
            on s1_0.id=msr2_0.space_id 
    left join
        member m1_0 
            on s1_0.leader_id=m1_0.id 
    left join
        form f1_0 
            on s1_0.form_id=f1_0.space_id 
    where
        msr1_0.member_id=? 
    group by
        s1_0.id,
        s1_0.created_at,
        s1_0.updated_at,
        s1_0.category,
        s1_0.field_list,
        s1_0.name,
        s1_0.introduction,
        m1_0.id,
        s1_0.form_id,
        s1_0.banner_url

```


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #157 
