### PR TITLE
feat: 회고 마감 API 구현

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectApi.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectApi.java
@@ -1,6 +1,12 @@
 package org.layer.domain.retrospect.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -31,4 +37,24 @@ public interface RetrospectApi {
 	@Operation(summary = "회고 삭제", description = "특정 팀 스페이스에서 작성했던 회고를 삭제하는 기능입니다.")
 	ResponseEntity<RetrospectListGetResponse> deleteRetrospect(@PathVariable("spaceId") Long spaceId,
 		@PathVariable("retrospectId") Long retrospectId, @MemberId Long memberId);
+
+	@Operation(summary = "회고 마감", description = "특정 팀 스페이스에서 작성했던 회고를 마감하는 기능입니다. </br> Note: 스페이스 내 모든 인원이 작성해야 가능합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "회고 마감 성공",
+			content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "400", description = "회고 마감 실패",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(name = "회고 마감 실패", value = """
+                                    {
+                                      "name": "NOT_COMPLETE_RETROSPECT_MEMBER",
+                                      "message": "회고를 작성하지 않은 팀원이 있습니다."
+                                    }
+                                    """
+				)
+			}))
+	})
+	ResponseEntity<Void> closeRetrospect(
+		@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId,
+		@MemberId Long memberId);
 }

--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/RetrospectController.java
@@ -75,4 +75,16 @@ public class RetrospectController implements RetrospectApi {
 		return ResponseEntity.ok().build();
 	}
 
+	@Override
+	@PatchMapping("/{retrospectId}/close")
+	public ResponseEntity<Void> closeRetrospect(
+		@PathVariable("spaceId") Long spaceId,
+		@PathVariable("retrospectId") Long retrospectId,
+		@MemberId Long memberId) {
+
+		retrospectService.closeRetrospect(spaceId, retrospectId, memberId);
+
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
+++ b/layer-common/src/main/java/org/layer/common/exception/RetrospectExceptionType.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RetrospectExceptionType implements ExceptionType {
 	INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "회고 마감기한이 유효하지 않습니다."),
+	NOT_COMPLETE_RETROSPECT_MEMBER(HttpStatus.BAD_REQUEST, "회고를 작성하지 않은 팀원이 있습니다."),
 	DEADLINE_PASSED(HttpStatus.BAD_REQUEST, "회고 마감기한이 지났습니다."),
 	DEADLINE_NOT_PASSED(HttpStatus.BAD_REQUEST, "회고가 마감되지 않았습니다."),
 	NOT_PROCEEDING_RETROSPECT(HttpStatus.BAD_REQUEST, "진행중인 회고가 아닙니다."),

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -82,4 +82,10 @@ public class Retrospect extends BaseTimeEntity {
 		this.introduction = introduction;
 		this.deadline = deadline;
 	}
+
+	public void updateRetrospectStatus(RetrospectStatus retrospectStatus){
+		isProceedingRetrospect();
+
+		this.retrospectStatus = retrospectStatus;
+	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Team.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Team.java
@@ -19,7 +19,7 @@ public class Team {
 			.orElseThrow(() -> new MemberSpaceRelationException(NOT_FOUND_MEMBER_SPACE_RELATION));
 	}
 
-	public int getTeamMemberCount(){
+	public long getTeamMemberCount(){
 		return memberSpaceRelations.size();
 	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고 마감 API 를 구현했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="785" alt="스크린샷 2024-08-26 오후 3 43 28" src="https://github.com/user-attachments/assets/3743c027-73e7-4c0e-bb9a-97b63c0eb5aa">

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#185
- closed #185
