### PR TITLE
fix: 회고 분석 팀원도 조회 가능하도록 변경

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/analyze/service/AnalyzeService.java
+++ b/layer-api/src/main/java/org/layer/domain/analyze/service/AnalyzeService.java
@@ -16,6 +16,8 @@ import org.layer.domain.question.repository.QuestionRepository;
 import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.layer.domain.space.entity.Space;
+import org.layer.domain.space.entity.Team;
+import org.layer.domain.space.repository.MemberSpaceRelationRepository;
 import org.layer.domain.space.repository.SpaceRepository;
 import org.layer.external.ai.dto.response.OpenAIResponse;
 import org.layer.external.ai.service.OpenAIService;
@@ -36,6 +38,7 @@ public class AnalyzeService {
 	private final AnalyzeRepository analyzeRepository;
 	private final QuestionRepository questionRepository;
 	private final AnswerRepository answerRepository;
+	private final MemberSpaceRelationRepository memberSpaceRelationRepository;
 
 	private final OpenAIService openAIService;
 
@@ -73,9 +76,9 @@ public class AnalyzeService {
 	}
 
 	public AnalyzeGetResponse getAnalyze(Long spaceId, Long retrospectId, Long memberId) {
-		// 리더인지 확인
-		Space space = spaceRepository.findByIdOrThrow(spaceId);
-		space.isLeaderSpace(memberId);
+		// 해당 스페이스 팀원인지 검증
+		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
+		team.validateTeamMembership(memberId);
 
 		Analyze analyze = analyzeRepository.findByRetrospectIdOrThrow(retrospectId);
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고 분석 팀원도 조회가능하도록 변경했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #187
