### PR TITLE
chore: 회고 마감일 nullable 하게 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectCreateRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/controller/dto/request/RetrospectCreateRequest.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 public record RetrospectCreateRequest(
 	@Schema(description = "회고 제목", example = "중간 발표 이후 회고")
@@ -17,7 +16,6 @@ public record RetrospectCreateRequest(
 	@NotNull
 	List<QuestionCreateRequest> questions,
 	@Schema(description = "회고 마감 일자", example = "")
-	@NotNull
 	LocalDateTime deadline,
 	@Schema(description = "질문을 수정한 경우 true", example = "true")
 	Boolean isNewForm,

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -57,8 +57,6 @@ public class RetrospectService {
 		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
 		team.validateTeamMembership(memberId);
 
-
-
 		Retrospect retrospect = getRetrospect(request, spaceId);
 		Retrospect savedRetrospect = retrospectRepository.save(retrospect);
 

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -41,7 +41,6 @@ public class Retrospect extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private RetrospectStatus retrospectStatus;
 
-	@NotNull
 	private LocalDateTime deadline;
 
 	@Builder
@@ -61,7 +60,7 @@ public class Retrospect extends BaseTimeEntity {
 	}
 
 	public void validateDeadline(LocalDateTime currentTime) {
-		if (currentTime.isAfter(this.deadline)) {
+		if (this.deadline != null && currentTime.isAfter(this.deadline)) {
 			throw new RetrospectException(DEADLINE_PASSED);
 		}
 	}


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고 마감일을 nullable 하게 수정했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #215 
