### PR TITLE
chore: 회고 답변 직후에 응답 확인할 수 있도록 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -181,11 +181,10 @@ public class AnswerService {
         Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
         team.validateTeamMembership(memberId);
 
-        Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
-        retrospect.validateRetrospectStatusDone();
-
         // answer 뽑기
         Answers answers = new Answers(answerRepository.findAllByRetrospectId(retrospectId));
+        answers.validateIsWriteDone(memberId, retrospectId);
+
         List<Long> questionIds = answers.getAnswers().stream().map(Answer::getQuestionId).toList();
         List<Long> memberIds = answers.getAnswers().stream().map(Answer::getMemberId).toList();
 

--- a/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
+++ b/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
@@ -28,7 +28,6 @@ public class Answers {
 
 	private final List<Answer> answers;
 
-
 	public String getAnswerToQuestion(Long questionId, Long memberId) {
 		return answers.stream()
 			.filter(answer -> answer.getQuestionId().equals(questionId) && answer.getMemberId().equals(memberId))
@@ -43,12 +42,20 @@ public class Answers {
 			.anyMatch(answer -> answer.getMemberId().equals(memberId));
 	}
 
+	public void validateIsWriteDone(Long memberId, Long retrospectId) {
+		WriteStatus writeStatus = getWriteStatus(memberId, retrospectId);
+
+		if (!writeStatus.equals(WriteStatus.DONE)) {
+			throw new AnswerException(NOT_ANSWERED);
+		}
+	}
+
 	public WriteStatus getWriteStatus(Long memberId, Long retrospectId) {
 		boolean isDoneWrite = answers.stream()
 			.filter(answer -> answer.getRetrospectId().equals(retrospectId))
 			.filter(answer -> answer.getMemberId().equals(memberId))
 			.anyMatch(answer -> answer.getAnswerStatus().equals(AnswerStatus.DONE));
-		if(isDoneWrite){
+		if (isDoneWrite) {
 			return WriteStatus.DONE;
 		}
 
@@ -56,7 +63,7 @@ public class Answers {
 			.filter(answer -> answer.getRetrospectId().equals(retrospectId))
 			.filter(answer -> answer.getMemberId().equals(memberId))
 			.anyMatch(answer -> answer.getAnswerStatus().equals(AnswerStatus.TEMPORARY));
-		if(isTemporaryWrite){
+		if (isTemporaryWrite) {
 			return WriteStatus.PROCEEDING;
 		}
 
@@ -70,7 +77,7 @@ public class Answers {
 
 		Set<Long> answerMembers = new HashSet<>();
 
-		if(!answersByRetrospectId.containsKey(retrospectId)){
+		if (!answersByRetrospectId.containsKey(retrospectId)) {
 			return 0L;
 		}
 
@@ -111,9 +118,10 @@ public class Answers {
 		}
 	}
 
-	public String getTotalAnswer(Long rangeQuestionId, Long numberQuestionId){
+	public String getTotalAnswer(Long rangeQuestionId, Long numberQuestionId) {
 		Map<Long, String> answerConcatMap = answers.stream()
-			.filter(answer -> !answer.getQuestionId().equals(rangeQuestionId) && !answer.getQuestionId().equals(numberQuestionId))
+			.filter(answer -> !answer.getQuestionId().equals(rangeQuestionId) && !answer.getQuestionId()
+				.equals(numberQuestionId))
 			.collect(Collectors.groupingBy(
 				Answer::getMemberId, Collectors.mapping(Answer::getContent, Collectors.joining(" "))));
 
@@ -125,10 +133,11 @@ public class Answers {
 		return String.join("\n&&\n", answerMap.values());
 	}
 
-	public String getIndividualAnswer(Long rangeQuestionId, Long numberQuestionId, Long memberId){
+	public String getIndividualAnswer(Long rangeQuestionId, Long numberQuestionId, Long memberId) {
 		Map<Long, String> answerConcatMap = answers.stream()
 			.filter(answer -> answer.getMemberId().equals(memberId))
-			.filter(answer -> !answer.getQuestionId().equals(rangeQuestionId) && !answer.getQuestionId().equals(numberQuestionId))
+			.filter(answer -> !answer.getQuestionId().equals(rangeQuestionId) && !answer.getQuestionId()
+				.equals(numberQuestionId))
 			.collect(Collectors.groupingBy(
 				Answer::getMemberId, Collectors.mapping(Answer::getContent, Collectors.joining(" "))));
 
@@ -139,7 +148,6 @@ public class Answers {
 
 		return String.join("\n&&\n", answerMap.values());
 	}
-
 
 	public int getGoalCompletionRate(Long questionId) {
 
@@ -152,7 +160,7 @@ public class Answers {
 			}
 		}
 
-		if(count == ZERO){
+		if (count == ZERO) {
 			throw new AnswerException(NOT_CONTAIN_ANSWERS);
 		}
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [X] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고 답변 직후에 응답 확인할 수 있도록 수정했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과

를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="742" alt="스크린샷 2024-09-12 오후 9 02 30" src="https://github.com/user-attachments/assets/f2b81752-1842-4f32-914d-73d35cc3f4ce">


### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #236 
