### PR TITLE
fix: Table 어노테이션으로 복합 유니크 제약조건 추가

### DIFF
--- a/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "socialType", "socialId" }) })
 public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
중복 요청으로 인한 중복 회원가입을 방지하기 위해 social_id, social_type에 복합 유니크 제약조건을 걸었습니다.
운영 DB에도 alter문으로 유니크 조건 추가했습니다!

+DB 보니까 social_id 중복으로 된 회원은 없어서 아직 실제로 중복 회원가입이 된 것 같지는 않습니다!

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


### 발생한 쿼리 첨부
h2 DB에 ddl-auto: create으로 실행했을 때 발생한 쿼리
<img width="585" alt="스크린샷 2024-11-20 오후 7 41 17" src="https://github.com/user-attachments/assets/a01f1f0e-2c44-45fd-80ec-b31e48439dec">

운영 DB에 `show create table member` 했을 때, 유니크 조건 추가된 것 캡처
<img width="1212" alt="스크린샷 2024-11-20 오후 7 49 50" src="https://github.com/user-attachments/assets/dc563edd-8936-4326-9d93-4e0d7dc0b06c">


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
