### PR TITLE
chore: docker container 로그 파일 제한 부분 추가

### DIFF
--- a/layer-api/infra/development/docker-compose.yaml
+++ b/layer-api/infra/development/docker-compose.yaml
@@ -25,6 +25,11 @@ services:
       - ./tokens:/config/tokens
     networks:
       - app-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   batch-job:
     image: docker.io/clean01/layer-server_layer-batch:latest #
@@ -40,6 +45,11 @@ services:
     depends_on:
       - java-app
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   admin-app:
     image: docker.io/clean01/layer-server_layer-admin:latest #
@@ -58,6 +68,11 @@ services:
     depends_on:
       - java-app
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   nginx:
     image: nginx:latest

--- a/layer-api/infra/production/docker-compose-blue.yaml
+++ b/layer-api/infra/production/docker-compose-blue.yaml
@@ -29,7 +29,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: "5"
+        max-file: "3"
 
   batch-job-blue:
     image: docker.io/clean01/layer-server_layer-batch:latest
@@ -49,7 +49,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: "5"
+        max-file: "3"
 
   admin-app-blue:
     image: docker.io/clean01/layer-server_layer-admin:latest #
@@ -72,7 +72,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: "5"
+        max-file: "3"
 
 networks:
   app-network:

--- a/layer-api/infra/production/docker-compose-blue.yaml
+++ b/layer-api/infra/production/docker-compose-blue.yaml
@@ -25,6 +25,11 @@ services:
       - ./tokens:/config/tokens
     networks:
       - app-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   batch-job-blue:
     image: docker.io/clean01/layer-server_layer-batch:latest
@@ -40,6 +45,11 @@ services:
     depends_on:
       - layer-api-blue
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   admin-app-blue:
     image: docker.io/clean01/layer-server_layer-admin:latest #
@@ -58,6 +68,11 @@ services:
     depends_on:
       - layer-api-blue
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
 networks:
   app-network:

--- a/layer-api/infra/production/docker-compose-green.yaml
+++ b/layer-api/infra/production/docker-compose-green.yaml
@@ -25,6 +25,11 @@ services:
       - ./tokens:/config/tokens
     networks:
       - app-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   batch-job-green:
     image: docker.io/clean01/layer-server_layer-batch:latest
@@ -40,6 +45,11 @@ services:
     depends_on:
       - layer-api-green
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   admin-app-green:
     image: docker.io/clean01/layer-server_layer-admin:latest #
@@ -58,6 +68,11 @@ services:
     depends_on:
       - layer-api-green
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
 networks:
   app-network:

--- a/layer-api/infra/production/docker-compose-green.yaml
+++ b/layer-api/infra/production/docker-compose-green.yaml
@@ -9,7 +9,7 @@ services:
       - redis-data:/data # Persistent data storage
     restart: always
     networks:
-      - app-network
+      - app-networkㅎ
 
   layer-api-green:
     image: docker.io/clean01/layer-server_layer-api:latest
@@ -29,7 +29,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: "5"
+        max-file: "3"
 
   batch-job-green:
     image: docker.io/clean01/layer-server_layer-batch:latest
@@ -49,7 +49,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: "5"
+        max-file: "3"
 
   admin-app-green:
     image: docker.io/clean01/layer-server_layer-admin:latest #
@@ -72,7 +72,7 @@ services:
       driver: "json-file"
       options:
         max-size: "10m"
-        max-file: "5"
+        max-file: "3"
 
 networks:
   app-network:


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- infra > development > docker-compose.yaml
- infra > production > docker-compose-blue.yaml
- infra > production > docker-compose-green.yaml

세 파일에 layer-api, layer-batch, layer-admin의 로그 파일 용량과 개수를 제한하는 부분을 추가했습니다.

```
    logging:
      driver: "json-file"
      options:
        max-size: "10m"
        max-file: "3"
```

파일 하나당 용량 10MB로 제한, 파일 개수 최대 3개로 제한


## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- chore/docker-container-log
- closed #
