### PR TITLE
fix: 특정 회고의 답변을 완료하지 않아도 완료된 회고를 볼 수 있도록 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/answer/controller/AnswerController.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/controller/AnswerController.java
@@ -48,7 +48,7 @@ public class AnswerController implements AnswerApi {
     @GetMapping("/analyze")
     public ResponseEntity<AnswerListGetResponse> getAnalyzeAnswer(@PathVariable("spaceId") Long spaceId,
                                                                   @PathVariable("retrospectId") Long retrospectId, @MemberId Long memberId) {
-        AnswerListGetResponse response = answerService.getAnalyzeAnswer(spaceId, retrospectId, memberId);
+        AnswerListGetResponse response = answerService.getAnalyzeAnswers(spaceId, retrospectId, memberId);
 
         return ResponseEntity.ok().body(response);
     }

--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -184,7 +184,7 @@ public class AnswerService {
 		return TemporaryAnswerListResponse.of(temporaryAnswers);
 	}
 
-	public AnswerListGetResponse getAnalyzeAnswer(Long spaceId, Long retrospectId, Long memberId) {
+	public AnswerListGetResponse getAnalyzeAnswers(Long spaceId, Long retrospectId, Long memberId) {
 		// 해당 스페이스 팀원인지 검증
 		Team team = new Team(memberSpaceRelationRepository.findAllBySpaceId(spaceId));
 		team.validateTeamMembership(memberId);

--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -192,7 +192,6 @@ public class AnswerService {
 		// 완료된 answer 뽑기
 		Answers answers = new Answers(
 			answerRepository.findAllByRetrospectIdAndAnswerStatus(retrospectId, AnswerStatus.DONE));
-		answers.validateIsWriteDone(memberId, retrospectId);
 
 		List<Long> questionIds = answers.getAnswers().stream().map(Answer::getQuestionId).toList();
 		List<Long> memberIds = answers.getAnswers().stream().map(Answer::getMemberId).toList();

--- a/layer-api/src/main/resources/application-test.yml
+++ b/layer-api/src/main/resources/application-test.yml
@@ -19,6 +19,9 @@ spring:
         format_sql: true
         show_sql: true
     open-in-view: false
+  sql:
+    init:
+      mode: never
 
   data:
     redis:
@@ -85,3 +88,9 @@ openai:
 
 admin:
   password: ${ADMIN_PASSWORD}
+
+discord:
+  webhook:
+    retrospect-url: ${DISCORD_RETROSPECT_URL}
+    space-url: ${DISCORD_SPACE_URL}
+    member-url: ${DISCORD_MEMBER_URL}

--- a/layer-api/src/main/resources/console-appender.xml
+++ b/layer-api/src/main/resources/console-appender.xml
@@ -5,22 +5,4 @@
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./log/layer-api.log</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${application.home:-.}/log/layer-api.%d{yyyy-MM-dd}.%i.log
-            </fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy
-                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>50MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>10</maxHistory>
-        </rollingPolicy>
-
-        <encoder>
-            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
-        </encoder>
-    </appender>
 </included>

--- a/layer-api/src/main/resources/logback-spring.xml
+++ b/layer-api/src/main/resources/logback-spring.xml
@@ -16,7 +16,6 @@
 
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
     </springProfile>
 
@@ -25,7 +24,15 @@
 
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+        </root>
+
+    </springProfile>
+
+    <springProfile name="test">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
         </root>
 
     </springProfile>

--- a/layer-api/src/test/java/org/layer/LayerApplicationTests.java
+++ b/layer-api/src/test/java/org/layer/LayerApplicationTests.java
@@ -6,9 +6,9 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class LayerApplicationTests {
-    // @Test
-    // void init() {
-    //
-    // }
+class LayerApplicationTests {
+    @Test
+    void init() {
+
+    }
 }

--- a/layer-api/src/test/java/org/layer/domain/answer/service/AnswerServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/answer/service/AnswerServiceTest.java
@@ -32,7 +32,7 @@ class AnswerServiceTest {
 
 		@Test
 		@DisplayName("특정 회고에 답변하지 않은 유저도 완료된 해당 회고를 조회할 수 있다.")
-		void test1() {
+		void getAnalyzeAnswersTest_1() {
 			// given
 			Long spaceId = 1L;
 			Long retrospectId = 1L;

--- a/layer-api/src/test/java/org/layer/domain/answer/service/AnswerServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/answer/service/AnswerServiceTest.java
@@ -1,0 +1,58 @@
+package org.layer.domain.answer.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.layer.domain.answer.controller.dto.response.AnswerListGetResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AnswerServiceTest {
+
+	@Autowired
+	private AnswerService answerService;
+
+	@Nested
+	@SqlGroup({
+		@Sql(value = "/sql/answer-service-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+		@Sql(value = "/sql/delete-all-test-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+
+	})
+	class 회고_답변_조회 {
+
+		@Test
+		@DisplayName("특정 회고에 답변하지 않은 유저도 완료된 해당 회고를 조회할 수 있다.")
+		void test1() {
+			// given
+			Long spaceId = 1L;
+			Long retrospectId = 1L;
+			Long memberId = 2L;
+
+			// when
+			AnswerListGetResponse analyzeAnswers = answerService.getAnalyzeAnswers(spaceId, retrospectId, memberId);
+
+			// then
+			assertThat(analyzeAnswers).isNotNull();
+			assertThat(analyzeAnswers.questions()).hasSize(2);
+			assertThat(analyzeAnswers.questions().get(0).questionContent()).isEqualTo("질문1");
+			assertThat(analyzeAnswers.questions().get(0).answers().get(0).answerContent()).isEqualTo("회고답변 1");
+			assertThat(analyzeAnswers.questions().get(1).answers().get(0).answerContent()).isEqualTo("회고답변 2");
+
+			assertThat(analyzeAnswers.individuals()).hasSize(1);
+			assertThat(analyzeAnswers.individuals().get(0).name()).isEqualTo("홍길동");
+			assertThat(analyzeAnswers.individuals().get(0).answers().get(0).answerContent()).isEqualTo("회고답변 1");
+			assertThat(analyzeAnswers.individuals().get(0).answers().get(1).answerContent()).isEqualTo("회고답변 2");
+		}
+	}
+
+}

--- a/layer-api/src/test/java/org/layer/domain/retrospect/service/RetrospectServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/retrospect/service/RetrospectServiceTest.java
@@ -1,8 +1,27 @@
 package org.layer.domain.retrospect.service;
 
+import static org.layer.domain.space.entity.SpaceField.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.entity.MemberRole;
+import org.layer.domain.member.entity.SocialType;
 import org.layer.domain.member.repository.MemberRepository;
+import org.layer.domain.question.enums.QuestionType;
+import org.layer.domain.retrospect.controller.dto.request.QuestionCreateRequest;
+import org.layer.domain.retrospect.controller.dto.request.RetrospectCreateRequest;
+import org.layer.domain.retrospect.entity.Retrospect;
+import org.layer.domain.retrospect.entity.RetrospectStatus;
 import org.layer.domain.retrospect.repository.RetrospectRepository;
+import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.entity.Space;
+import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
 import org.layer.domain.space.repository.SpaceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,53 +30,59 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class RetrospectServiceTest {
+class RetrospectServiceTest {
 
-    @Autowired
-    private RetrospectService retrospectService;
+	@Autowired
+	private RetrospectService retrospectService;
 
-    @Autowired
-    private RetrospectRepository retrospectRepository;
+	@Autowired
+	private RetrospectRepository retrospectRepository;
 
-    @Autowired
-    private MemberRepository memberRepository;
+	@Autowired
+	private MemberRepository memberRepository;
 
-    @Autowired
-    private SpaceRepository spaceRepository;
+	@Autowired
+	private SpaceRepository spaceRepository;
 
-    @Autowired
-    private MemberSpaceRelationRepository memberSpaceRelationRepository;
-//
-//   @Test
-//   void 정상입력의_경우_회고생성에_성공한다() {
-//       // given
-//       // TODO : 이 부분은 이렇게 처리할지 or data.sql로 처리할지 고민.
-//       Member member = Member.builder()
-//               .name("홍길동")
-//               .email("qwer@naver.com")
-//               .memberRole(MemberRole.USER)
-//               .socialType(SocialType.GOOGLE)
-//               .socialId("123456789")
-//               .build();
-//       Member member1 = memberRepository.saveAndFlush(member);
-//
-//       Space space = new Space(null, SpaceCategory.TEAM, List.of(DEVELOPMENT), "회고스페이스이름입니다", "회고스페이스 설명입니다", 1L, 1L);
-//       spaceRepository.saveAndFlush(space);
-//       memberSpaceRelationRepository.saveAndFlush(new MemberSpaceRelation(member1.getId(), space));
-//
-//       RetrospectCreateRequest request = new RetrospectCreateRequest("회고제목입니다", "회고소개입니다",
-//               List.of(new QuestionCreateRequest("질문1", QuestionType.PLAIN_TEXT.getStyle()),
-//                       new QuestionCreateRequest("질문2", QuestionType.PLAIN_TEXT.getStyle()),
-//                       new QuestionCreateRequest("질문3", QuestionType.PLAIN_TEXT.getStyle())),
-//               LocalDateTime.of(2024, 8, 4, 3, 5),
-//               false, null, null, null);
-//       // when
-//       Long savedId = retrospectService.createRetrospect(request, 1L, 1L);
-//
-//       // then
-//       Retrospect retrospect = retrospectRepository.findByIdOrThrow(savedId);
-//       Assertions.assertThat(retrospect)
-//               .extracting("title", "introduction", "retrospectStatus")
-//               .containsExactly("회고제목입니다", "회고소개입니다", RetrospectStatus.PROCEEDING);
-//   }
+	@Autowired
+	private MemberSpaceRelationRepository memberSpaceRelationRepository;
+
+	@Nested
+	class 회고_생성 {
+		@Test
+		@DisplayName("정상 입력의 경우 회고 생성에 성공한다.")
+		void createRetrospectTest_1() {
+			// given
+			Member member = Member.builder()
+				.name("홍길동")
+				.email("qwer@naver.com")
+				.memberRole(MemberRole.USER)
+				.socialType(SocialType.GOOGLE)
+				.socialId("123456789")
+				.build();
+			Member member1 = memberRepository.saveAndFlush(member);
+
+			Space space = new Space("banner-url", SpaceCategory.TEAM, List.of(DEVELOPMENT), "회고스페이스 이름", "회고스페이스 설명",
+				1L, 1L);
+			spaceRepository.saveAndFlush(space);
+			memberSpaceRelationRepository.saveAndFlush(new MemberSpaceRelation(member1.getId(), space));
+
+			RetrospectCreateRequest request = new RetrospectCreateRequest("회고제목입니다", "회고소개입니다",
+				List.of(new QuestionCreateRequest("질문1", QuestionType.PLAIN_TEXT.getStyle()),
+					new QuestionCreateRequest("질문2", QuestionType.PLAIN_TEXT.getStyle()),
+					new QuestionCreateRequest("질문3", QuestionType.PLAIN_TEXT.getStyle())),
+				LocalDateTime.of(2024, 8, 4, 3, 5),
+				false, null, null, null, false);
+
+			// when
+			Long savedId = retrospectService.createRetrospect(request, 1L, 1L);
+
+			// then
+			Retrospect retrospect = retrospectRepository.findByIdOrThrow(savedId);
+			Assertions.assertThat(retrospect)
+				.extracting("title", "introduction", "retrospectStatus")
+				.containsExactly("회고제목입니다", "회고소개입니다", RetrospectStatus.PROCEEDING);
+		}
+	}
+
 }

--- a/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
+++ b/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
@@ -42,14 +42,6 @@ public class Answers {
 			.anyMatch(answer -> answer.getMemberId().equals(memberId));
 	}
 
-	public void validateIsWriteDone(Long memberId, Long retrospectId) {
-		WriteStatus writeStatus = getWriteStatus(memberId, retrospectId);
-
-		if (!writeStatus.equals(WriteStatus.DONE)) {
-			throw new AnswerException(NOT_ANSWERED);
-		}
-	}
-
 	public WriteStatus getWriteStatus(Long memberId, Long retrospectId) {
 		boolean isDoneWrite = answers.stream()
 			.filter(answer -> answer.getRetrospectId().equals(retrospectId))

--- a/layer-domain/src/test/java/layer/domain/retrospect/entity/RetrospectTest.java
+++ b/layer-domain/src/test/java/layer/domain/retrospect/entity/RetrospectTest.java
@@ -8,7 +8,7 @@ import org.layer.domain.retrospect.entity.AnalysisStatus;
 import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.entity.RetrospectStatus;
 
-public class RetrospectTest {
+class RetrospectTest {
 
 	@Test
 	void 진행중인_회고는_진행여부로직에서_예외를_발생시키지_않는다() {


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 예전에는 조금 엄격하게 구현했었는데요! 회고 완료 후에 새로운 멤버가 들어와도 완료된 회고를 볼 수 있도록 기능을 수정했습니다.
- 검증 로직을 아예 제거했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
