### PR TITLE
fix: AnalyzeDetail의 rank -> analyze_detail_rank로 변경

### DIFF
--- a/layer-domain/src/main/java/org/layer/domain/analyze/entity/AnalyzeDetail.java
+++ b/layer-domain/src/main/java/org/layer/domain/analyze/entity/AnalyzeDetail.java
@@ -27,7 +27,7 @@ public class AnalyzeDetail {
 
 	private int count;
 
-	@Column(name = "`rank`")
+	@Column(name = "analyze_detail_rank")
 	private int rank;
 
 	@Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
AnalyzeDetail 엔티티에서 rank 컬럼의 이름을 변경했습니다.
아직 DB엔 적용하지 않았는데, dev에 합치기 전에 DB에서도 변경하겠습니다.
```java
	@Column(name = "analyze_detail_rank")
	private int rank;
```

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
ManyToOne이 없어서 그런 건 아닐까 여쭤봤었는데, 에러 난 곳을 다시 읽어보니까 그 문제는 아닌 것 같고

dev에서는 쿼리가 \`rank\`로 나가면서 분석이 잘 된다는 점, prod에서는 쿼리가 컬럼명이 그냥 rank로 나가고 그 주변에서 SQL 문법 오류가 난다는 점에 진짜 컬럼 이름에 문제가 있는 것 같아 아예 다른 걸로 변경했습니다


prod 환경에서 나가는 쿼리
<img width="1440" alt="스크린샷 2025-02-04 오후 10 03 23" src="https://github.com/user-attachments/assets/d0fda0ed-f16e-47e9-81f6-885bcffcf476" />

dev 환경에서 나가는 쿼리
<img width="825" alt="스크린샷 2025-02-05 오전 12 15 07" src="https://github.com/user-attachments/assets/c8958b1b-526c-4d0c-b685-cdfa0b30be9d" />



## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #
