### PR TITLE
refactor: 스페이스 단건 조회 리팩토링

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceRequest.java
@@ -2,6 +2,7 @@ package org.layer.domain.space.controller.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.layer.annotation.AtLeastNotNull;
 import org.layer.domain.space.entity.Space;
@@ -25,6 +26,7 @@ public class SpaceRequest {
             SpaceCategory category,
             @Schema(description = "진행중인 프로젝트 유형")
             @NotNull
+			@Min(1)
             List<SpaceField> fieldList,
 
             @Schema(description = "이름")

--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
@@ -6,9 +6,11 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
 import org.layer.common.dto.Meta;
+import org.layer.domain.form.entity.Form;
 import org.layer.domain.space.dto.Leader;
 import org.layer.domain.space.dto.SpaceMember;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
+import org.layer.domain.space.entity.Space;
 import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.entity.SpaceField;
 
@@ -30,28 +32,21 @@ public class SpaceResponse {
             @Schema(description = "진행중인 프로젝트 유형")
             @NotNull
             List<SpaceField> fieldList,
-
             @Schema(description = "이름")
             @NotNull
             String name,
-
             @Schema(description = "공간 설명")
             String introduction,
-
             @Schema(description = "설정된 회고 폼 아이디")
             Long formId,
             @Schema(description = "설정된 회고 폼 태그")
             String formTag,
-
             @Schema(description = "소속된 회원 수")
             Long memberCount,
-
             @Schema(description = "스페이스 배너 이미지")
             String bannerUrl,
-
             @Schema(description = "스페이스 생성 일자")
             LocalDateTime createdAt,
-
             @Schema(description = "스페이스 리더 아이디")
             Leader leader
     ) {
@@ -75,6 +70,22 @@ public class SpaceResponse {
                 .bannerUrl(space.getBannerUrl())
                 .createdAt(space.getCreatedAt())
                 .leader(space.getLeader())
+                .build();
+        }
+
+        public static SpaceWithMemberCountInfo of(Space space, Form form, Long memberCount, Leader leader) {
+            return SpaceWithMemberCountInfo.builder()
+                .id(space.getId())
+                .category(space.getCategory())
+                .fieldList(space.getFieldList())
+                .name(space.getName())
+                .introduction(space.getIntroduction())
+                .formId(space.getFormId())
+                .formTag(form.getFormTag().getTag())
+                .memberCount(memberCount)
+                .bannerUrl(space.getBannerUrl())
+                .createdAt(space.getCreatedAt())
+                .leader(leader)
                 .build();
         }
     }

--- a/layer-api/src/main/java/org/layer/global/exception/ApiSpaceExceptionType.java
+++ b/layer-api/src/main/java/org/layer/global/exception/ApiSpaceExceptionType.java
@@ -9,8 +9,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ApiSpaceExceptionType implements ExceptionType {
-    NOT_FOUND_SPACE(HttpStatus.NOT_FOUND, "찾을 수 없는 스페이스 입니다."),
+    NOT_FOUND_SPACE(NOT_FOUND, "찾을 수 없는 스페이스 입니다."),
     SPACE_LEADER_CANNOT_LEAVE(BAD_REQUEST, "스페이스를 팀장은 떠날 수 없어요."),
+    NOT_JOINED_SPACE(BAD_REQUEST,"소속되어 있지 않는 스페이스입니다."),
     SPACE_ALREADY_JOINED(BAD_REQUEST, "이미 가입한 스페이스에요.");
 
 

--- a/layer-api/src/test/java/org/layer/domain/fixture/FormFixture.java
+++ b/layer-api/src/test/java/org/layer/domain/fixture/FormFixture.java
@@ -1,0 +1,19 @@
+package org.layer.domain.fixture;
+
+import org.layer.domain.form.entity.Form;
+import org.layer.domain.form.entity.FormType;
+import org.layer.domain.form.enums.FormTag;
+
+public class FormFixture {
+
+	public static Form createFixture(Long memberId, Long spaceId){
+		return Form.builder()
+			.memberId(memberId)
+			.spaceId(spaceId)
+			.title("폼 제목1")
+			.introduction("폼 소개1")
+			.formType(FormType.CUSTOM)
+			.formTag(FormTag.KPT)
+			.build();
+	}
+}

--- a/layer-api/src/test/java/org/layer/domain/fixture/MemberFixture.java
+++ b/layer-api/src/test/java/org/layer/domain/fixture/MemberFixture.java
@@ -1,0 +1,17 @@
+package org.layer.domain.fixture;
+
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.entity.MemberRole;
+import org.layer.domain.member.entity.SocialType;
+
+public class MemberFixture {
+	public static Member createFixture(){
+		return Member.builder()
+			.name("이름1")
+			.email("이메일1")
+			.memberRole(MemberRole.USER)
+			.socialType(SocialType.KAKAO)
+			.socialId("소셜 id1")
+			.build();
+	}
+}

--- a/layer-api/src/test/java/org/layer/domain/fixture/MemberSpaceRelationFixture.java
+++ b/layer-api/src/test/java/org/layer/domain/fixture/MemberSpaceRelationFixture.java
@@ -1,0 +1,14 @@
+package org.layer.domain.fixture;
+
+import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.entity.Space;
+
+public class MemberSpaceRelationFixture {
+
+	public static MemberSpaceRelation createFixture(Space space, Long memberId){
+		return MemberSpaceRelation.builder()
+			.space(space)
+			.memberId(memberId)
+			.build();
+	}
+}

--- a/layer-api/src/test/java/org/layer/domain/fixture/SpaceFixture.java
+++ b/layer-api/src/test/java/org/layer/domain/fixture/SpaceFixture.java
@@ -1,4 +1,4 @@
-package org.layer.domain.space;
+package org.layer.domain.fixture;
 
 import java.util.List;
 
@@ -8,7 +8,7 @@ import org.layer.domain.space.entity.SpaceField;
 
 public class SpaceFixture {
 
-	public static Space createSpaceFixture(Long leaderId){
+	public static Space createFixture(Long leaderId, Long formId){
 		return Space.builder()
 			.bannerUrl("url1")
 			.category(SpaceCategory.TEAM)
@@ -16,7 +16,7 @@ public class SpaceFixture {
 			.name("스페이스 이름1")
 			.introduction("스페이스 소개1")
 			.leaderId(leaderId)
-			.formId(10001L)
+			.formId(formId)
 			.build();
 	}
 }

--- a/layer-api/src/test/java/org/layer/domain/space/SpaceServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/space/SpaceServiceTest.java
@@ -1,24 +1,41 @@
 package org.layer.domain.space;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.layer.global.exception.ApiSpaceExceptionType.*;
 import static org.layer.global.exception.SpaceExceptionType.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.layer.domain.fixture.FormFixture;
+import org.layer.domain.fixture.MemberFixture;
+import org.layer.domain.fixture.MemberSpaceRelationFixture;
+import org.layer.domain.fixture.SpaceFixture;
+import org.layer.domain.form.entity.Form;
+import org.layer.domain.form.enums.FormTag;
+import org.layer.domain.form.repository.FormRepository;
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.repository.MemberRepository;
 import org.layer.domain.space.controller.dto.SpaceRequest;
+import org.layer.domain.space.controller.dto.SpaceResponse;
+import org.layer.domain.space.entity.MemberSpaceRelation;
 import org.layer.domain.space.entity.Space;
+import org.layer.domain.space.entity.SpaceCategory;
 import org.layer.domain.space.exception.SpaceException;
+import org.layer.domain.space.repository.MemberSpaceRelationRepository;
 import org.layer.domain.space.repository.SpaceRepository;
 import org.layer.domain.space.service.SpaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 public class SpaceServiceTest {
 
 	@Autowired
@@ -27,15 +44,24 @@ public class SpaceServiceTest {
 	@Autowired
 	private SpaceRepository spaceRepository;
 
+	@Autowired
+	private FormRepository formRepository;
+
+	@Autowired
+	private MemberSpaceRelationRepository memberSpaceRelationRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
 	@Nested
-	class 스페이스_수정{
+	class 스페이스_수정 {
 
 		@Test
 		@DisplayName("스페이스를 수정할 수 있다.")
-		void updateSpaceTest1(){
+		void updateSpaceTest1() {
 			// given
 			Long memberId = 1L;
-			Space space = SpaceFixture.createSpaceFixture(memberId);
+			Space space = SpaceFixture.createFixture(memberId, 10001L);
 			Space savedSpace = spaceRepository.save(space);
 
 			SpaceRequest.UpdateSpaceRequest request = new SpaceRequest.UpdateSpaceRequest("new url",
@@ -54,10 +80,10 @@ public class SpaceServiceTest {
 
 		@Test
 		@DisplayName("리더가 아닐 경우, 스페이스를 수정할 수 없다.")
-		void updateSpaceTest2(){
+		void updateSpaceTest2() {
 			// given
 			Long memberId = 2L;
-			Space space = SpaceFixture.createSpaceFixture(1L);
+			Space space = SpaceFixture.createFixture(1L, 10001L);
 			Space savedSpace = spaceRepository.save(space);
 
 			SpaceRequest.UpdateSpaceRequest request = new SpaceRequest.UpdateSpaceRequest("new url",
@@ -67,6 +93,76 @@ public class SpaceServiceTest {
 			assertThatThrownBy(() -> spaceService.updateSpace(memberId, request))
 				.isInstanceOf(SpaceException.class)
 				.hasMessageContaining(CAN_ONLY_SPACE_LEADER.message());
+		}
+	}
+
+	@Nested
+	class 스페이스_단건조회 {
+		@Test
+		@DisplayName("스페이스 단건 조회를 할 수 있다.")
+		void getSpaceByIdTest1() {
+			// given
+			Form form = FormFixture.createFixture(null, null);
+			Form savedForm = formRepository.save(form);
+
+			Member member = MemberFixture.createFixture();
+
+			Member savedMember = memberRepository.save(member);
+			Long memberId = savedMember.getId();
+			Long anotherMemberId = 10003L;
+
+			Space space = SpaceFixture.createFixture(memberId, savedForm.getId());
+			Space savedSpace = spaceRepository.save(space);
+
+			MemberSpaceRelation team = MemberSpaceRelationFixture.createFixture(savedSpace, memberId);
+			MemberSpaceRelation team2 = MemberSpaceRelationFixture.createFixture(savedSpace, anotherMemberId);
+			memberSpaceRelationRepository.saveAll(List.of(team, team2));
+
+			// when
+			SpaceResponse.SpaceWithMemberCountInfo res = spaceService.getSpaceById(memberId, savedSpace.getId());
+
+			// then
+			assertThat(res).isNotNull();
+			assertThat(res.memberCount()).isEqualTo(2);
+			assertThat(res.category()).isEqualTo(SpaceCategory.TEAM);
+			assertThat(res.name()).isEqualTo("스페이스 이름1");
+			assertThat(res.formTag()).isEqualTo(FormTag.KPT.getTag());
+			assertThat(res.bannerUrl()).isEqualTo("url1");
+			assertThat(res.leader().name()).isEqualTo("이름1");
+		}
+
+		@Test
+		@DisplayName("속하지 않은 스페이스의 단건 조회는 불가능하다.")
+		void getSpaceByIdTest2() {
+			// given
+			Form form = FormFixture.createFixture(null, null);
+			Form savedForm = formRepository.save(form);
+
+			Member member = MemberFixture.createFixture();
+
+			Member savedMember = memberRepository.save(member);
+			Long memberId = savedMember.getId();
+
+			Space space = SpaceFixture.createFixture(memberId, savedForm.getId());
+			Space savedSpace = spaceRepository.save(space);
+
+			// when, then
+			assertThatThrownBy(() -> spaceService.getSpaceById(memberId, savedSpace.getId()))
+				.isInstanceOf(SpaceException.class)
+				.hasMessageContaining(NOT_JOINED_SPACE.message());
+		}
+	}
+
+	@Nested
+	class 스페이스_생성 {
+		@Test
+		@DisplayName("스페이스를 생성할 수 있다.")
+		void createSpaceTest1() {
+			// given
+
+			// when
+
+			// then
 		}
 	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
+++ b/layer-domain/src/main/java/org/layer/domain/form/entity/Form.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,6 +46,7 @@ public class Form extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private FormTag formTag; // 기본 템플릿의 명칭. ex) KPT, 5F
 
+	@Builder
 	public Form(Long memberId, Long spaceId, String title, String introduction, FormType formType, FormTag formTag) {
 		this.memberId = memberId;
 		this.spaceId = spaceId;

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/Leader.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/Leader.java
@@ -1,6 +1,8 @@
 package org.layer.domain.space.dto;
 
 
+import org.layer.domain.member.entity.Member;
+
 import lombok.Builder;
 
 @Builder
@@ -8,4 +10,7 @@ public record Leader(
         Long id,
         String name
 ) {
+	public static Leader of(Member member){
+		return new Leader(member.getId(), member.getName());
+	}
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/entity/Space.java
@@ -79,6 +79,10 @@ public class Space extends BaseTimeEntity {
         this.introduction = introduction;
     }
 
+    public void updateBannerUrl(String bannerUrl){
+        this.bannerUrl = bannerUrl;
+    }
+
     @Builder
     public Space(String bannerUrl, SpaceCategory category, List<SpaceField> fieldList, String name, String introduction,
         Long leaderId, Long formId) {

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/MemberSpaceRelationRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/MemberSpaceRelationRepository.java
@@ -2,6 +2,7 @@ package org.layer.domain.space.repository;
 
 
 import org.layer.domain.space.entity.MemberSpaceRelation;
+import org.layer.domain.space.entity.Space;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,8 @@ public interface MemberSpaceRelationRepository extends JpaRepository<MemberSpace
 
     @Query("SELECT m FROM MemberSpaceRelation m JOIN FETCH m.space WHERE m.memberId = :memberId")
     List<MemberSpaceRelation> findAllByMemberId(@Param("memberId") Long memberId);
+
+    Long countAllBySpace(Space space);
+
+    Boolean existsByMemberIdAndSpace(Long memberId, Space space);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 스페이스 단건 조회 로직을 리팩토링했습니다.
- 기존 쿼리는 보기가 다소 불편하다고 생각했습니다. N번 join 중첩이 있어 이를 개선하기 위해 쿼리를 분리하여 구현했습니다.
- 추가적으로 테스트 코드도 작성했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #317 
