### PR TITLE
feat: 활성 유저 집계 기능 구현

### DIFF
--- a/.github/workflows/aws-cicd-dev.yml
+++ b/.github/workflows/aws-cicd-dev.yml
@@ -105,7 +105,7 @@ jobs:
     name: Deploy
     needs: [ build, setup ]
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+  #  if: github.event_name != 'pull_request'
     env:
       DEPLOY_TARGET: ${{ needs.setup.outputs.deploy_target }}
       HOST_IP: ${{ needs.setup.outputs.host_ip }}

--- a/.github/workflows/aws-cicd-dev.yml
+++ b/.github/workflows/aws-cicd-dev.yml
@@ -105,7 +105,7 @@ jobs:
     name: Deploy
     needs: [ build, setup ]
     runs-on: ubuntu-latest
-  #  if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     env:
       DEPLOY_TARGET: ${{ needs.setup.outputs.deploy_target }}
       HOST_IP: ${{ needs.setup.outputs.host_ip }}

--- a/layer-api/src/main/java/org/layer/admin/aop/MemberActivityAspect.java
+++ b/layer-api/src/main/java/org/layer/admin/aop/MemberActivityAspect.java
@@ -1,0 +1,66 @@
+package org.layer.admin.aop;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.layer.admin.cache.MemberActivityCache;
+import org.springframework.stereotype.Component;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MemberActivityAspect {
+
+	private final MemberActivityCache memberActivityCache;
+
+	@Pointcut("@annotation(io.swagger.v3.oas.annotations.Operation)")
+	public void operationAnnotatedMethod() {}
+
+	@Around("operationAnnotatedMethod()")
+	public Object trackMemberActivity(ProceedingJoinPoint joinPoint) throws Throwable {
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		Method method = signature.getMethod();
+		Operation operation = method.getAnnotation(Operation.class);
+		String summary = operation != null ? operation.summary() : "unknown";
+
+		Long memberId = extractMemberId(signature, joinPoint.getArgs());
+
+		if (memberId != null) {
+			memberActivityCache
+				.activityMap
+				.computeIfAbsent(memberId, id -> new ConcurrentHashMap<>())
+				.merge(summary, 1, Integer::sum);
+
+			log.info("📊 User [{}] called API '{}'", memberId, summary);
+		}
+
+		return joinPoint.proceed();
+	}
+
+	private Long extractMemberId(MethodSignature signature, Object[] args) {
+		Annotation[][] paramAnnotations = signature.getMethod().getParameterAnnotations();
+
+		for (int i = 0; i < paramAnnotations.length; i++) {
+			for (Annotation annotation : paramAnnotations[i]) {
+				if (annotation.annotationType().getSimpleName().equals("MemberId")) {
+					return (Long) args[i];
+				}
+			}
+		}
+		return null;
+	}
+}
+
+
+

--- a/layer-api/src/main/java/org/layer/admin/cache/MemberActivityCache.java
+++ b/layer-api/src/main/java/org/layer/admin/cache/MemberActivityCache.java
@@ -9,4 +9,30 @@ import org.springframework.stereotype.Component;
 public class MemberActivityCache {
 	public final Map<Long, Map<String, Integer>> activityMap = new ConcurrentHashMap<>();
 
+	public String getMessage(){
+		if (activityMap.isEmpty()) {
+			return "📊 현재 집계된 활동 데이터가 없습니다.";
+		}
+
+		StringBuilder message = new StringBuilder();
+		message.append("\n---\n\n");
+		message.append("📊 [일일 유저 API 호출 통계]\n\n");
+
+		activityMap.forEach((memberId, activity) -> {
+			message.append("👤 유저 ID: ").append(memberId).append("\n");
+
+			// 호출 횟수 기준 내림차순 정렬 후 최대 5개까지만 출력
+			activity.entrySet().stream()
+				.sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+				.limit(5)
+				.forEach(entry ->
+					message.append("  - ").append(entry.getKey()).append(": ").append(entry.getValue()).append("회\n")
+				);
+
+			message.append("\n---\n\n");
+		});
+
+		return message.toString();
+	}
+
 }

--- a/layer-api/src/main/java/org/layer/admin/cache/MemberActivityCache.java
+++ b/layer-api/src/main/java/org/layer/admin/cache/MemberActivityCache.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.cache;
+package org.layer.admin.cache;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/layer-api/src/main/java/org/layer/admin/member/controller/AdminMemberApi.java
+++ b/layer-api/src/main/java/org/layer/admin/member/controller/AdminMemberApi.java
@@ -1,10 +1,11 @@
-package org.layer.domain.admin.member.controller;
+package org.layer.admin.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.layer.domain.admin.member.controller.dto.GetMembersActivitiesResponse;
+
+import org.layer.admin.member.controller.dto.GetMembersActivitiesResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 

--- a/layer-api/src/main/java/org/layer/admin/member/controller/AdminMemberController.java
+++ b/layer-api/src/main/java/org/layer/admin/member/controller/AdminMemberController.java
@@ -1,8 +1,9 @@
-package org.layer.domain.admin.member.controller;
+package org.layer.admin.member.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.domain.admin.member.controller.dto.GetMembersActivitiesResponse;
-import org.layer.domain.admin.member.service.AdminMemberService;
+
+import org.layer.admin.member.controller.dto.GetMembersActivitiesResponse;
+import org.layer.admin.member.service.AdminMemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/layer-api/src/main/java/org/layer/admin/member/controller/dto/GetMemberActivityResponse.java
+++ b/layer-api/src/main/java/org/layer/admin/member/controller/dto/GetMemberActivityResponse.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.member.controller.dto;
+package org.layer.admin.member.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/layer-api/src/main/java/org/layer/admin/member/controller/dto/GetMembersActivitiesResponse.java
+++ b/layer-api/src/main/java/org/layer/admin/member/controller/dto/GetMembersActivitiesResponse.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.member.controller.dto;
+package org.layer.admin.member.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/layer-api/src/main/java/org/layer/admin/member/service/AdminMemberService.java
+++ b/layer-api/src/main/java/org/layer/admin/member/service/AdminMemberService.java
@@ -1,21 +1,14 @@
-package org.layer.domain.admin.member.service;
+package org.layer.admin.member.service;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.common.dto.RecentActivityDto;
-import org.layer.domain.admin.member.controller.dto.GetMemberActivityResponse;
-import org.layer.domain.admin.member.controller.dto.GetMembersActivitiesResponse;
+
+import org.layer.admin.member.controller.dto.GetMembersActivitiesResponse;
 import org.layer.domain.answer.repository.AdminAnswerRepository;
-import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.repository.AdminMemberRepository;
 import org.layer.domain.space.repository.AdminMemberSpaceRelationRepository;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/layer-api/src/main/java/org/layer/admin/retrospect/controller/AdminRetrospectApi.java
+++ b/layer-api/src/main/java/org/layer/admin/retrospect/controller/AdminRetrospectApi.java
@@ -1,12 +1,12 @@
-package org.layer.domain.admin.retrospect.controller;
+package org.layer.admin.retrospect.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectsGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectsGetResponse;
 import org.layer.domain.retrospect.dto.AdminRetrospectCountGroupBySpaceGetResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/layer-api/src/main/java/org/layer/admin/retrospect/controller/AdminRetrospectController.java
+++ b/layer-api/src/main/java/org/layer/admin/retrospect/controller/AdminRetrospectController.java
@@ -1,9 +1,9 @@
-package org.layer.domain.admin.retrospect.controller;
+package org.layer.admin.retrospect.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectsGetResponse;
-import org.layer.domain.admin.retrospect.service.AdminRetrospectService;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectsGetResponse;
+import org.layer.admin.retrospect.service.AdminRetrospectService;
 import org.layer.domain.retrospect.dto.AdminRetrospectCountGroupBySpaceGetResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/layer-api/src/main/java/org/layer/admin/retrospect/controller/dto/AdminRetrospectCountGetResponse.java
+++ b/layer-api/src/main/java/org/layer/admin/retrospect/controller/dto/AdminRetrospectCountGetResponse.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.retrospect.controller.dto;
+package org.layer.admin.retrospect.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/layer-api/src/main/java/org/layer/admin/retrospect/controller/dto/AdminRetrospectsGetResponse.java
+++ b/layer-api/src/main/java/org/layer/admin/retrospect/controller/dto/AdminRetrospectsGetResponse.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.retrospect.controller.dto;
+package org.layer.admin.retrospect.controller.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/layer-api/src/main/java/org/layer/admin/retrospect/service/AdminRetrospectService.java
+++ b/layer-api/src/main/java/org/layer/admin/retrospect/service/AdminRetrospectService.java
@@ -1,8 +1,8 @@
-package org.layer.domain.admin.retrospect.service;
+package org.layer.admin.retrospect.service;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectsGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectsGetResponse;
 import org.layer.domain.retrospect.dto.AdminRetrospectCountGroupBySpaceGetResponse;
 import org.layer.domain.retrospect.dto.AdminRetrospectGetResponse;
 import org.layer.domain.retrospect.repository.RetrospectAdminRepository;

--- a/layer-api/src/main/java/org/layer/admin/space/controller/AdminSpaceApi.java
+++ b/layer-api/src/main/java/org/layer/admin/space/controller/AdminSpaceApi.java
@@ -1,13 +1,14 @@
-package org.layer.domain.admin.space.controller;
+package org.layer.admin.space.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
-import org.layer.domain.admin.space.controller.dto.AdminSpaceCountGetResponse;
-import org.layer.domain.admin.space.controller.dto.AdminSpacesGetResponse;
+
+import org.layer.admin.space.controller.dto.AdminSpaceCountGetResponse;
+import org.layer.admin.space.controller.dto.AdminSpacesGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/layer-api/src/main/java/org/layer/admin/space/controller/AdminSpaceController.java
+++ b/layer-api/src/main/java/org/layer/admin/space/controller/AdminSpaceController.java
@@ -1,10 +1,11 @@
-package org.layer.domain.admin.space.controller;
+package org.layer.admin.space.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
-import org.layer.domain.admin.space.controller.dto.AdminSpaceCountGetResponse;
-import org.layer.domain.admin.space.controller.dto.AdminSpacesGetResponse;
-import org.layer.domain.admin.space.service.AdminSpaceService;
+
+import org.layer.admin.space.controller.dto.AdminSpaceCountGetResponse;
+import org.layer.admin.space.controller.dto.AdminSpacesGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
+import org.layer.admin.space.service.AdminSpaceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/layer-api/src/main/java/org/layer/admin/space/controller/dto/AdminSpaceCountGetResponse.java
+++ b/layer-api/src/main/java/org/layer/admin/space/controller/dto/AdminSpaceCountGetResponse.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.space.controller.dto;
+package org.layer.admin.space.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/layer-api/src/main/java/org/layer/admin/space/controller/dto/AdminSpacesGetResponse.java
+++ b/layer-api/src/main/java/org/layer/admin/space/controller/dto/AdminSpacesGetResponse.java
@@ -1,4 +1,4 @@
-package org.layer.domain.admin.space.controller.dto;
+package org.layer.admin.space.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/layer-api/src/main/java/org/layer/admin/space/service/AdminSpaceService.java
+++ b/layer-api/src/main/java/org/layer/admin/space/service/AdminSpaceService.java
@@ -1,9 +1,10 @@
-package org.layer.domain.admin.space.service;
+package org.layer.admin.space.service;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.domain.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
-import org.layer.domain.admin.space.controller.dto.AdminSpaceCountGetResponse;
-import org.layer.domain.admin.space.controller.dto.AdminSpacesGetResponse;
+
+import org.layer.admin.space.controller.dto.AdminSpaceCountGetResponse;
+import org.layer.admin.space.controller.dto.AdminSpacesGetResponse;
+import org.layer.admin.retrospect.controller.dto.AdminRetrospectCountGetResponse;
 import org.layer.domain.retrospect.repository.RetrospectAdminRepository;
 import org.layer.domain.space.dto.AdminSpaceGetResponse;
 import org.layer.domain.space.repository.SpaceAdminRepository;

--- a/layer-api/src/main/java/org/layer/domain/admin/cache/MemberActivityCache.java
+++ b/layer-api/src/main/java/org/layer/domain/admin/cache/MemberActivityCache.java
@@ -1,0 +1,12 @@
+package org.layer.domain.admin.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberActivityCache {
+	public final Map<Long, Map<String, Integer>> activityMap = new ConcurrentHashMap<>();
+
+}

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -18,7 +18,7 @@ public class MemberActivityScheduler {
 	private final ApplicationEventPublisher eventPublisher;
 
 	// 매일 오후 9시에 실행됨
-	@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 0 21 * * *")
 	public void logDailyMemberActivity() {
 		log.info("🌙 유저 활동 통계 작업 시작");
 

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -18,7 +18,7 @@ public class MemberActivityScheduler {
 	private final ApplicationEventPublisher eventPublisher;
 
 	// 매일 오후 9시에 실행됨
-	@Scheduled(cron = "0 */3 * * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
 	public void logDailyMemberActivity() {
 		log.info("🌙 유저 활동 통계 작업 시작");
 

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -4,12 +4,14 @@ import org.layer.admin.cache.MemberActivityCache;
 import org.layer.discord.event.MemberActivityEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
+@Component
 public class MemberActivityScheduler {
 
 	private final MemberActivityCache memberActivityCache;

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -1,8 +1,11 @@
 package org.layer.scheduler;
 
+import java.time.LocalDateTime;
+
 import org.layer.admin.cache.MemberActivityCache;
 import org.layer.discord.event.MemberActivityEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,12 +20,15 @@ public class MemberActivityScheduler {
 	private final MemberActivityCache memberActivityCache;
 	private final ApplicationEventPublisher eventPublisher;
 
+	private final RedisTemplate<String, String> redisTemplate;
+
 	// 매일 오후 9시에 실행됨
 	@Scheduled(cron = "0 0 21 * * *")
 	public void logDailyMemberActivity() {
 		log.info("🌙 유저 활동 통계 작업 시작");
 
 		eventPublisher.publishEvent(new MemberActivityEvent(memberActivityCache.activityMap));
+		redisTemplate.opsForValue().set(LocalDateTime.now().toString(), memberActivityCache.getMessage());
 		memberActivityCache.activityMap.clear();
 	}
 }

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -16,7 +16,7 @@ public class MemberActivityScheduler {
 	private final ApplicationEventPublisher eventPublisher;
 
 	// 매일 오후 9시에 실행됨
-	@Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 */3 * * * *", zone = "Asia/Seoul")
 	public void logDailyMemberActivity() {
 		log.info("🌙 유저 활동 통계 작업 시작");
 

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -1,0 +1,26 @@
+package org.layer.scheduler;
+
+import org.layer.admin.cache.MemberActivityCache;
+import org.layer.discord.event.MemberActivityEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MemberActivityScheduler {
+
+	private final MemberActivityCache memberActivityCache;
+	private final ApplicationEventPublisher eventPublisher;
+
+	// 매일 오후 9시에 실행됨
+	@Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+	public void logDailyMemberActivity() {
+		log.info("🌙 유저 활동 통계 작업 시작");
+
+		eventPublisher.publishEvent(new MemberActivityEvent(memberActivityCache.activityMap));
+		memberActivityCache.activityMap.clear();
+	}
+}

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -83,6 +83,7 @@ discord:
     space-url: ${DISCORD_SPACE_URL}
     member-url: ${DISCORD_MEMBER_URL}
     error-url: ${DISCORD_ERROR_URL}
+    member-activity-url: ${DISCORD_MEMBER_ACTIVITY_URL}
 
 # actuator
 management:

--- a/layer-api/src/main/resources/application-dev.yml
+++ b/layer-api/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
 
   data:
     redis:
-      host: ${DEV_REDIS_HOST}
+      host: localhost
       port: ${DEV_REDIS_PORT}
       password: ${DEV_REDIS_PASSWORD}
 

--- a/layer-api/src/main/resources/application-local.yml
+++ b/layer-api/src/main/resources/application-local.yml
@@ -88,3 +88,4 @@ discord:
     space-url: ${DISCORD_SPACE_URL}
     member-url: ${DISCORD_MEMBER_URL}
     error-url: ${DISCORD_ERROR_URL}
+    member-activity-url: ${DISCORD_MEMBER_ACTIVITY_URL}

--- a/layer-api/src/main/resources/application-prod.yml
+++ b/layer-api/src/main/resources/application-prod.yml
@@ -83,6 +83,7 @@ discord:
     space-url: ${DISCORD_SPACE_URL}
     member-url: ${DISCORD_MEMBER_URL}
     error-url: ${DISCORD_ERROR_URL}
+    member-activity-url: ${DISCORD_MEMBER_ACTIVITY_URL}
 
 # actuator
 management:

--- a/layer-api/src/main/resources/application-test.yml
+++ b/layer-api/src/main/resources/application-test.yml
@@ -81,3 +81,4 @@ discord:
     space-url: ${DISCORD_SPACE_URL}
     member-url: ${DISCORD_MEMBER_URL}
     error-url: ${DISCORD_ERROR_URL}
+    member-activity-url: ${DISCORD_MEMBER_ACTIVITY_URL}

--- a/layer-external/src/main/java/org/layer/discord/DiscordAppender.java
+++ b/layer-external/src/main/java/org/layer/discord/DiscordAppender.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.layer.discord.infra.DiscordWebhookErrorClient;
+import org.layer.discord.infra.DiscordWebhookMemberActivityClient;
 import org.layer.discord.infra.DiscordWebhookMemberClient;
 import org.layer.discord.infra.DiscordWebhookRetrospectClient;
 import org.layer.discord.infra.DiscordWebhookSpaceClient;
@@ -27,6 +28,8 @@ public class DiscordAppender {
 	private final DiscordWebhookSpaceClient spaceClient;
 	private final DiscordWebhookErrorClient errorClient;
 
+	private final DiscordWebhookMemberActivityClient memberActivityClient;
+
 	public void createRetrospectAppend(String title, Long memberId, LocalDateTime now) {
 		String content = "회고";
 		int green = 3066993;
@@ -43,7 +46,7 @@ public class DiscordAppender {
 		spaceClient.sendNotification(body);
 	}
 
-	public void createMember(String name, Long memberId, LocalDateTime now){
+	public void createMember(String name, Long memberId, LocalDateTime now) {
 		Map<String, Object> embed = new HashMap<>();
 		embed.put("title", "\uD83D\uDE80[회원 가입] 새로운 유저가 가입하였습니다.\uD83D\uDE80");
 		embed.put("description", memberId + " 번째 유저가 회원가입하였습니다.");
@@ -85,7 +88,7 @@ public class DiscordAppender {
 		body.put("fields", List.of(field1, field2, field3));
 
 		Map<String, Object> payload = new HashMap<>();
-		payload.put("embeds", new Object[]{body});
+		payload.put("embeds", new Object[] {body});
 
 		errorClient.sendNotification(payload);
 	}
@@ -110,6 +113,28 @@ public class DiscordAppender {
 		body.put("content", "새 " + content + " 생성 알림");
 		body.put("embeds", List.of(embed));
 		return body;
+	}
+
+	public void aggregateMemberActivity(Map<Long, Map<String, Integer>> activities) {
+		if (activities.isEmpty())
+			return;
+
+		StringBuilder message = new StringBuilder();
+		message.append("📊 [일일 유저 API 호출 통계]\n\n");
+
+		for (Long memberId : activities.keySet()) {
+			message.append("👤 유저 ID: ").append(memberId.toString()).append("\n");
+
+			activities.get(memberId).forEach((summary, count) ->
+				message.append("  - ").append(summary).append(": ").append(count).append("회\n")
+			);
+			message.append("\n");
+		}
+
+		Map<String, Object> payload = Map.of("content", message.toString());
+		memberActivityClient.sendNotification(payload);
+
+		log.info("✅ Discord에 유저 활동 통계 전송 완료");
 	}
 
 }

--- a/layer-external/src/main/java/org/layer/discord/event/MemberActivityEvent.java
+++ b/layer-external/src/main/java/org/layer/discord/event/MemberActivityEvent.java
@@ -1,0 +1,11 @@
+package org.layer.discord.event;
+
+import java.util.Map;
+
+public record MemberActivityEvent(
+	Map<Long, Map<String, Integer>> activities
+) {
+	public static MemberActivityEvent of(Map<Long, Map<String, Integer>> activities){
+		return new MemberActivityEvent(activities);
+	}
+}

--- a/layer-external/src/main/java/org/layer/discord/event/MemberActivityEventListener.java
+++ b/layer-external/src/main/java/org/layer/discord/event/MemberActivityEventListener.java
@@ -1,0 +1,20 @@
+package org.layer.discord.event;
+
+import org.layer.discord.DiscordAppender;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class MemberActivityEventListener {
+	private final DiscordAppender discordAppender;
+
+	@EventListener
+	public void handleSignUpEvent(MemberActivityEvent event) {
+		discordAppender.aggregateMemberActivity(event.activities());
+	}
+}

--- a/layer-external/src/main/java/org/layer/discord/event/MemberActivityEventListener.java
+++ b/layer-external/src/main/java/org/layer/discord/event/MemberActivityEventListener.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 @Component
-@Profile("prod")
+@Profile("dev")
 @RequiredArgsConstructor
 public class MemberActivityEventListener {
 	private final DiscordAppender discordAppender;

--- a/layer-external/src/main/java/org/layer/discord/event/MemberActivityEventListener.java
+++ b/layer-external/src/main/java/org/layer/discord/event/MemberActivityEventListener.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 @Component
-@Profile("dev")
+@Profile("prod")
 @RequiredArgsConstructor
 public class MemberActivityEventListener {
 	private final DiscordAppender discordAppender;

--- a/layer-external/src/main/java/org/layer/discord/infra/DiscordWebhookMemberActivityClient.java
+++ b/layer-external/src/main/java/org/layer/discord/infra/DiscordWebhookMemberActivityClient.java
@@ -1,0 +1,14 @@
+package org.layer.discord.infra;
+
+import java.util.Map;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "DiscordWebhookMemberActivityClient", url = "${discord.webhook.member-activity-url}")
+public interface DiscordWebhookMemberActivityClient {
+	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+	void sendNotification(@RequestBody Map<String, Object> body);
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 활성 유저에 대한 정보가 있으면 다음 기능에 큰 도움이 될 것 같아 구현해봤습니다.
- 매일 데이터가 초기화되기 때문에 간단하게 로컬캐시로 구현해봤습니다. 테스트 용도이기에 팀원분들의 의견을 받아보고 추후에 redis나 DB 사용을 고민해보겠습니다!
- 기존 서비스 로직의 수정을 최소화하기 위해 AOP 로 구현했습니다.
-🚨 yml 설정파일도 수정해야 합니다 !

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
- 결과는 디스코드 참고해주시면 될 것 같습니다 !

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #331 
