### PR TITLE
fix: 중복 회원가입, 탈퇴 버그 수정

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/auth/service/AuthService.java
+++ b/layer-api/src/main/java/org/layer/domain/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package org.layer.domain.auth.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.layer.domain.auth.controller.dto.*;
-import org.layer.domain.common.time.Time;
 import org.layer.domain.jwt.JwtToken;
 import org.layer.domain.jwt.exception.AuthException;
 import org.layer.domain.jwt.exception.AuthExceptionType;
@@ -11,12 +10,16 @@ import org.layer.domain.jwt.service.JwtService;
 import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.entity.SocialType;
 import org.layer.domain.member.service.MemberService;
-import org.layer.discord.event.SignUpEvent;
 import org.layer.oauth.dto.service.MemberInfoServiceResponse;
 import org.layer.oauth.service.OAuthService;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.layer.domain.jwt.exception.AuthExceptionType.DUPLICATED_SIGN_UP_REQUEST;
 
 
 @Slf4j
@@ -28,9 +31,9 @@ public class AuthService {
     private final OAuthService appleService;
     private final JwtService jwtService;
     private final MemberService memberService;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    private final ApplicationEventPublisher eventPublisher;
-    private final Time time;
+    private static final String SIGN_UP_LOCK_KEY = "signup:lock";
 
     //== 로그인 ==//
     @Transactional
@@ -48,24 +51,45 @@ public class AuthService {
     public SignUpResponse signUp(final String socialAccessToken, final SignUpRequest signUpRequest) {
         MemberInfoServiceResponse memberInfo = getMemberInfo(signUpRequest.socialType(), socialAccessToken);
 
-        // 이미 있는 회원인지 확인
-        isNewMember(memberInfo.socialType(), memberInfo.socialId());
+        String lockKey = SIGN_UP_LOCK_KEY + signUpRequest.socialType() + "_" + memberInfo.socialId();
+        String lockValue = UUID.randomUUID().toString();
+        boolean lockAcquired = false;
 
-        // DB에 회원 저장
-        Member member = memberService.saveMember(signUpRequest, memberInfo);
-        publishCreateRetrospectEvent(member);
+        Member member = null;
+        JwtToken jwtToken = null;
 
-        // 토큰 발급
-        JwtToken jwtToken = jwtService.issueToken(member.getId(), member.getMemberRole());
+        try {
+            // 1. Redis lock 설정
+            lockAcquired = Boolean.TRUE.equals(redisTemplate.opsForValue()
+                    .setIfAbsent(lockKey, lockValue, Duration.ofSeconds(15)));
+
+            if(!lockAcquired) {
+                throw new AuthException(DUPLICATED_SIGN_UP_REQUEST);
+            }
+
+            // 2. 이미 있는 회원인지 확인
+            isNewMember(memberInfo.socialType(), memberInfo.socialId());
+
+            // 3. DB에 회원 저장
+            member = memberService.saveMember(signUpRequest, memberInfo);
+
+            // 4. 토큰 발급
+            jwtToken = jwtService.issueToken(member.getId(), member.getMemberRole());
+
+        } catch(Exception e) {
+            log.info("Another process is already handling signing up: {}, socialId: {}, name: {}", signUpRequest.socialType(), memberInfo.socialId(), signUpRequest.name());
+            log.error("Error in signUp: {}", e.getMessage(), e);
+        } finally {
+            // 5. Redis lock 해제 (현재 락을 가진 주체만 해제)
+            if (lockAcquired) {
+                String currentLockValue = (String)redisTemplate.opsForValue().get(lockKey);
+                if (lockValue.equals(currentLockValue)) {
+                    redisTemplate.delete(lockKey);
+                }
+            }
+        }
+
         return SignUpResponse.of(member, jwtToken);
-    }
-
-    private void publishCreateRetrospectEvent(final Member member) {
-        eventPublisher.publishEvent(SignUpEvent.of(
-            member.getName(),
-            member.getId(),
-            time.now()
-        ));
     }
 
     //== 로그아웃 ==//

--- a/layer-api/src/main/java/org/layer/domain/jwt/exception/AuthExceptionType.java
+++ b/layer-api/src/main/java/org/layer/domain/jwt/exception/AuthExceptionType.java
@@ -11,7 +11,7 @@ public enum AuthExceptionType implements ExceptionType {
      * 400
      */
     INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 방식의 로그인입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다.");
+    DUPLICATED_SIGN_UP_REQUEST(HttpStatus.BAD_REQUEST, "중복된 회원 가입 요청입니다. (다른 요청이 이미 처리 중)");
 
 
     private final HttpStatus status;

--- a/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
+++ b/layer-api/src/main/java/org/layer/domain/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package org.layer.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
-import org.layer.common.exception.BaseCustomException;
 import org.layer.domain.analyze.entity.Analyze;
 import org.layer.domain.analyze.entity.AnalyzeDetail;
 import org.layer.domain.analyze.enums.AnalyzeDetailType;
@@ -11,6 +10,7 @@ import org.layer.domain.common.time.Time;
 import org.layer.domain.member.controller.dto.*;
 import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.entity.SocialType;
+import org.layer.domain.member.exception.MemberException;
 import org.layer.domain.member.repository.MemberRepository;
 import org.layer.domain.retrospect.dto.SpaceRetrospectDto;
 import org.layer.domain.retrospect.entity.RetrospectStatus;
@@ -29,7 +29,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.layer.domain.member.entity.MemberRole.USER;
-import static org.layer.global.exception.ApiMemberExceptionType.*;
+import static org.layer.global.exception.ApiMemberExceptionType.NOT_A_NEW_MEMBER;
+import static org.layer.global.exception.ApiMemberExceptionType.NOT_FOUND_USER;
 
 @RequiredArgsConstructor
 @Service
@@ -46,27 +47,27 @@ public class MemberService {
 	// sign-in만을 위한 메서드. 멤버가 없을시 회원가입이 필요함을 알려준다.
 	// 회원이 진짜로 없는 error의 경우와 회원 가입이 필요하다는 응답을 구분하기 위함
 	public Member getMemberBySocialInfoForSignIn(String socialId, SocialType socialType) {
-		return memberRepository.findBySocialIdAndSocialType(socialId, socialType)
-			.orElseThrow(() -> new BaseCustomException(ApiMemberExceptionType.NEED_TO_REGISTER));
+		return memberRepository.findValidMember(socialId, socialType)
+				.orElseThrow(() -> new MemberException(ApiMemberExceptionType.NEED_TO_REGISTER));
 	}
 
 	public void checkIsNewMember(String socialId, SocialType socialType) {
-		Optional<Member> memberOpt = memberRepository.findBySocialIdAndSocialType(socialId, socialType);
+		Optional<Member> memberOpt = memberRepository.findValidMember(socialId, socialType);
 
 		if (memberOpt.isPresent()) {
-			throw new BaseCustomException(NOT_A_NEW_MEMBER);
+			throw new MemberException(NOT_A_NEW_MEMBER);
 		}
 	}
 
 	@Transactional
 	public Member saveMember(SignUpRequest signUpRequest, MemberInfoServiceResponse memberInfo) {
 		Member member = Member.builder()
-			.name(signUpRequest.name())
-			.memberRole(USER)
-			.email(memberInfo.email())
-			.socialId(memberInfo.socialId())
-			.socialType(memberInfo.socialType())
-			.build();
+				.name(signUpRequest.name())
+				.memberRole(USER)
+				.email(memberInfo.email())
+				.socialId(memberInfo.socialId())
+				.socialType(memberInfo.socialType())
+				.build();
 
 		memberRepository.save(member);
 
@@ -75,28 +76,27 @@ public class MemberService {
 
 	public Member getMemberByMemberId(Long memberId) {
 		return memberRepository.
-			findById(memberId)
-			.orElseThrow(() -> new BaseCustomException(NOT_FOUND_USER));
+				findById(memberId)
+				.orElseThrow(() -> new MemberException(NOT_FOUND_USER));
 	}
 
 	@Transactional
 	public void withdrawMember(Long memberId) {
-		Member currentMember = memberRepository.findById(memberId)
-			.orElseThrow(() -> new BaseCustomException(NOT_FOUND_USER));
+		Member currentMember = memberRepository.findValidMemberByIdOrThrow(memberId);
 		currentMember.deleteMember();
 	}
 
 	@Transactional
 	public UpdateMemberInfoResponse updateMemberInfo(Long memberId, UpdateMemberInfoRequest updateMemberInfoRequest) {
-		Member member = memberRepository.findByIdOrThrow(memberId);
+		Member member = memberRepository.findValidMemberByIdOrThrow(memberId);
 		member.updateName(updateMemberInfoRequest.name());
 		member.updateProfileImageUrl(updateMemberInfoRequest.profileImageUrl());
 
 		return UpdateMemberInfoResponse.builder()
-			.memberId(member.getId())
-			.name(member.getName())
-			.profileImageUrl(member.getProfileImageUrl())
-			.build();
+				.memberId(member.getId())
+				.name(member.getName())
+				.profileImageUrl(member.getProfileImageUrl())
+				.build();
 	}
 
 	@Transactional(readOnly = true)
@@ -106,14 +106,14 @@ public class MemberService {
 
 		List<SpaceRetrospectDto> recentRetrospects = new ArrayList<>();
 		spaceIds.forEach(spaceId -> {
-				Optional<SpaceRetrospectDto> spaceRetrospectDto = retrospectRepository.findFirstBySpaceIdAndRetrospectStatusAndDeadlineAfterOrderByDeadline(
+			Optional<SpaceRetrospectDto> spaceRetrospectDto = retrospectRepository.findFirstBySpaceIdAndRetrospectStatusAndDeadlineAfterOrderByDeadline(
 					spaceId, RetrospectStatus.DONE, time.now().minusMonths(TWO_MONTHS));
-				spaceRetrospectDto.ifPresent(recentRetrospects::add);
-			});
+			spaceRetrospectDto.ifPresent(recentRetrospects::add);
+		});
 
 		List<Long> retrospectIds = recentRetrospects.stream().map(r -> r.getRetrospect().getId()).toList();
 		Map<Long, SpaceRetrospectDto> spaceRetrospectDtoMap = recentRetrospects.stream()
-			.collect(Collectors.toMap(r -> r.getRetrospect().getId(), r -> r));
+				.collect(Collectors.toMap(r -> r.getRetrospect().getId(), r -> r));
 
 		List<Analyze> analyzes = analyzeRepository.findAllByMemberIdAndRetrospectIdInQuery(memberId, retrospectIds);
 
@@ -136,7 +136,7 @@ public class MemberService {
 			goodAnalyzes.add(GetMemberRecentGoodAnalyzeResponse.of(spaceRetrospectDto, goodAnalyzeDetail.getContent()));
 			badAnalyzes.add(GetMemberRecentBadAnalyzeResponse.of(spaceRetrospectDto, badAnalyzeDetail.getContent()));
 			improvementAnalyzes.add(GetMemberRecentImprovementAnalyzeResponse.of(spaceRetrospectDto,
-				improvementAnalyzeDetail.getContent()));
+					improvementAnalyzeDetail.getContent()));
 		});
 
 		return GetMemberAnalyzesResponse.of(recentAnalyzes, goodAnalyzes, badAnalyzes, improvementAnalyzes);

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -1,38 +1,37 @@
 package org.layer.domain.space.service;
 
-import static org.layer.global.exception.ApiMemberSpaceRelationExceptionType.*;
-import static org.layer.global.exception.ApiSpaceExceptionType.*;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.layer.common.dto.Meta;
+import org.layer.discord.event.CreateSpaceEvent;
 import org.layer.domain.actionItem.repository.ActionItemRepository;
 import org.layer.domain.common.time.Time;
-import org.layer.discord.event.CreateSpaceEvent;
 import org.layer.domain.form.entity.Form;
 import org.layer.domain.form.repository.FormRepository;
 import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.repository.MemberRepository;
-import org.layer.domain.space.dto.Leader;
-import org.layer.domain.space.dto.SpaceWithMemberCount;
-import org.layer.domain.space.entity.Team;
-import org.layer.storage.service.StorageService;
 import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.layer.domain.space.controller.dto.SpaceRequest;
 import org.layer.domain.space.controller.dto.SpaceResponse;
+import org.layer.domain.space.dto.Leader;
+import org.layer.domain.space.dto.SpaceWithMemberCount;
 import org.layer.domain.space.entity.MemberSpaceRelation;
 import org.layer.domain.space.entity.Space;
 import org.layer.domain.space.entity.SpaceCategory;
+import org.layer.domain.space.entity.Team;
 import org.layer.domain.space.exception.MemberSpaceRelationException;
 import org.layer.domain.space.exception.SpaceException;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
 import org.layer.domain.space.repository.SpaceRepository;
+import org.layer.storage.service.StorageService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static org.layer.global.exception.ApiMemberSpaceRelationExceptionType.NOT_FOUND_MEMBER_SPACE_RELATION;
+import static org.layer.global.exception.ApiSpaceExceptionType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -129,7 +128,7 @@ public class SpaceService {
 			form = formRepository.findByIdOrThrow(space.getFormId());
 		}
 		Long memberCount = memberSpaceRelationRepository.countAllBySpace(space);
-		Leader leader = Leader.of(memberRepository.findByIdOrThrow(space.getLeaderId()));
+		Leader leader = Leader.of(memberRepository.findValidMemberByIdOrThrow(space.getLeaderId()));
 
 		return SpaceResponse.SpaceWithMemberCountInfo.of(space, form, memberCount, leader);
 	}
@@ -143,7 +142,7 @@ public class SpaceService {
 			form = formRepository.findByIdOrThrow(space.getFormId());
 		}
 		Long memberCount = memberSpaceRelationRepository.countAllBySpace(space);
-		Leader leader = Leader.of(memberRepository.findByIdOrThrow(space.getLeaderId()));
+		Leader leader = Leader.of(memberRepository.findValidMemberByIdOrThrow(space.getLeaderId()));
 
 		return SpaceResponse.SpaceWithMemberCountInfo.of(space, form, memberCount, leader);
 	}

--- a/layer-api/src/test/java/org/layer/domain/auth/service/AuthServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,121 @@
+package org.layer.domain.auth.service;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.layer.domain.auth.controller.dto.SignUpRequest;
+import org.layer.domain.auth.controller.dto.SignUpResponse;
+import org.layer.domain.jwt.JwtToken;
+import org.layer.domain.jwt.service.JwtService;
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.entity.SocialType;
+import org.layer.domain.member.repository.MemberRepository;
+import org.layer.oauth.dto.service.MemberInfoServiceResponse;
+import org.layer.oauth.service.KakaoService;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AuthServiceTest {
+
+    @InjectMocks
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private KakaoService kakaoService;
+
+
+    @Container
+    static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.0.8-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", () -> redisContainer.getHost());
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+    }
+
+    @BeforeAll
+    static void setup() {
+        redisContainer.start();
+    }
+
+    @DisplayName("동시 회원가입 요청이 들어오면 하나만 성공해야한다.")
+    @Test
+    void signUp_onlyOneSuccessInDupReqs() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        SocialType socialType = SocialType.KAKAO;
+        String socialId = "1234567890";
+        String name = "레이어";
+        String email = "layer@test.com";
+        String kakaoAccessToken = "fake-kakao-access-token";
+
+        SignUpRequest signUpRequest = new SignUpRequest(socialType, name);
+        MemberInfoServiceResponse memberInfoServiceResponse = new MemberInfoServiceResponse(socialId, socialType, email);
+
+        Mockito.when(jwtService.issueToken(any(), any())).thenReturn(new JwtToken("fake-access", "fake-refresh"));
+        Mockito.when(kakaoService.getMemberInfo(any())).thenReturn(memberInfoServiceResponse);
+
+        // when : 동시 10번 회원가입 요청
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    SignUpResponse response = authService.signUp(kakaoAccessToken, signUpRequest);
+                    if (response != null && response.socialId().equals(socialId)) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        Optional<Member> validMember = memberRepository.findValidMember(socialId, socialType);
+
+        // then
+        assertTrue(validMember.isPresent(), "회원 가입된 멤버가 존재해야함");
+        assertEquals(1, successCount.get(), "동시에 요청한 회원가입 중 하나만 성공해야 함");
+        assertEquals(9, failCount.get(), "나머지 요청은 모두 실패해야 함");
+    }
+}

--- a/layer-api/src/test/java/org/layer/domain/auth/service/AuthServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/auth/service/AuthServiceTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.layer.domain.auth.controller.dto.SignUpRequest;
 import org.layer.domain.auth.controller.dto.SignUpResponse;
-import org.layer.domain.jwt.JwtToken;
-import org.layer.domain.jwt.service.JwtService;
 import org.layer.domain.member.entity.Member;
 import org.layer.domain.member.entity.SocialType;
 import org.layer.domain.member.repository.MemberRepository;
@@ -49,9 +47,6 @@ class AuthServiceTest {
     RedisTemplate<String, String> redisTemplate;
 
     @MockBean
-    private JwtService jwtService;
-
-    @MockBean
     private KakaoService kakaoService;
 
 
@@ -89,7 +84,6 @@ class AuthServiceTest {
         SignUpRequest signUpRequest = new SignUpRequest(socialType, name);
         MemberInfoServiceResponse memberInfoServiceResponse = new MemberInfoServiceResponse(socialId, socialType, email);
 
-        Mockito.when(jwtService.issueToken(any(), any())).thenReturn(new JwtToken("fake-access", "fake-refresh"));
         Mockito.when(kakaoService.getMemberInfo(any())).thenReturn(memberInfoServiceResponse);
 
         // when : 동시 10번 회원가입 요청

--- a/layer-api/src/test/java/org/layer/domain/member/service/MemberServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MemberServiceTest {
+  
+}

--- a/layer-api/src/test/java/org/layer/domain/member/service/MemberServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/member/service/MemberServiceTest.java
@@ -1,4 +1,83 @@
-import static org.junit.jupiter.api.Assertions.*;
+package org.layer.domain.member.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.layer.domain.auth.controller.dto.SignUpRequest;
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.entity.SocialType;
+import org.layer.domain.member.exception.MemberException;
+import org.layer.domain.member.repository.MemberRepository;
+import org.layer.oauth.dto.service.MemberInfoServiceResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
 class MemberServiceTest {
-  
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        memberRepository.deleteAll();
+    }
+
+    @DisplayName("탈퇴한 회원은 조회되지 않는다.")
+    @Test
+    void withdrawTest() {
+        // given
+        String socialId = "12345678";
+        String email = "layer@example.com";
+        String username = "레이어";
+        SocialType socialType = SocialType.KAKAO;
+
+        SignUpRequest signUpRequest = new SignUpRequest(socialType, username);
+        MemberInfoServiceResponse memberInfoServiceResponse = new MemberInfoServiceResponse(socialId, socialType, email);
+
+        // when
+        Member member = memberService.saveMember(signUpRequest, memberInfoServiceResponse);
+        memberService.withdrawMember(member.getId());
+        Optional<Member> findMember = memberRepository.findValidMember(socialId, socialType);
+
+        // then
+        assertThat(findMember).isEmpty();
+        Assertions.assertThrows(MemberException.class, () -> memberRepository.findValidMemberByIdOrThrow(member.getId()));
+    }
+
+    @DisplayName("탈퇴 후 같은 회원이 같은 소셜 로그인 방식으로 재가입할 수 있다.")
+    @Test
+    void withdrawAndRejoin() {
+        // given
+        String socialId = "12345678";
+        String email = "layer@example.com";
+        String username = "레이어";
+        SocialType socialType = SocialType.KAKAO;
+
+        SignUpRequest signUpRequest = new SignUpRequest(socialType, username);
+        MemberInfoServiceResponse memberInfoServiceResponse = new MemberInfoServiceResponse(socialId, socialType, email);
+
+        // when
+        Member withdrawMember = memberService.saveMember(signUpRequest, memberInfoServiceResponse);
+        memberService.withdrawMember(withdrawMember.getId());
+
+        Member rejoinMember = memberService.saveMember(signUpRequest, memberInfoServiceResponse);
+
+
+        // then
+        assertThat(withdrawMember).isNotEqualTo(rejoinMember);
+        assertThat(rejoinMember.getDeletedAt()).isNull();
+        assertThat(withdrawMember.getId()).isNotEqualTo(rejoinMember.getId());
+    }
+
 }

--- a/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/entity/Member.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "socialType", "socialId" }) })
 public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberCustomRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberCustomRepository.java
@@ -1,0 +1,12 @@
+package org.layer.domain.member.repository;
+
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.entity.SocialType;
+
+import java.util.Optional;
+
+public interface MemberCustomRepository {
+    Optional<Member> findValidMember(String socialId, SocialType socialType);
+
+    Member findValidMemberByIdOrThrow(Long memberId);
+}

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepository.java
@@ -1,21 +1,11 @@
 package org.layer.domain.member.repository;
 
-import static org.layer.global.exception.MemberExceptionType.*;
-
 import org.layer.domain.member.entity.Member;
-import org.layer.domain.member.entity.SocialType;
-import org.layer.domain.member.exception.MemberException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
-
-    default Member findByIdOrThrow(Long memberId) {
-        return findById(memberId).orElseThrow(() -> new MemberException(NOT_FOUND_USER));
-    }
-
+public interface MemberRepository extends MemberCustomRepository, JpaRepository<Member, Long> {
     List<Member> findAllByIdIn(List<Long> memberIds);
+
 }

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepositoryImpl.java
@@ -7,7 +7,6 @@ import org.layer.domain.member.entity.QMember;
 import org.layer.domain.member.entity.SocialType;
 import org.layer.domain.member.exception.MemberException;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.layer.global.exception.MemberExceptionType.NOT_FOUND_USER;
@@ -35,17 +34,17 @@ public class MemberRepositoryImpl implements MemberCustomRepository {
 
     @Override
     public Member findValidMemberByIdOrThrow(Long memberId) {
-        List<Member> fetch = queryFactory
+        Member member = queryFactory
                 .select(QMember.member)
                 .from(QMember.member)
                 .where(QMember.member.id.eq(memberId)
                         .and(QMember.member.deletedAt.isNull())
-                ).fetch();
+                ).fetchOne();
 
-        if(fetch.isEmpty()) {
+        if(member == null) {
             throw new MemberException(NOT_FOUND_USER);
         }
 
-        return fetch.get(0);
+        return member;
     }
 }

--- a/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,51 @@
+package org.layer.domain.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.layer.domain.member.entity.Member;
+import org.layer.domain.member.entity.QMember;
+import org.layer.domain.member.entity.SocialType;
+import org.layer.domain.member.exception.MemberException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.layer.global.exception.MemberExceptionType.NOT_FOUND_USER;
+
+
+public class MemberRepositoryImpl implements MemberCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public MemberRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Optional<Member> findValidMember(String socialId, SocialType socialType) {
+        Member member = queryFactory
+                .select(QMember.member)
+                .from(QMember.member)
+                .where(QMember.member.socialId.eq(socialId)
+                        .and(QMember.member.socialType.eq(socialType))
+                        .and(QMember.member.deletedAt.isNull())
+                ).fetchFirst();
+
+        return Optional.ofNullable(member);
+    }
+
+    @Override
+    public Member findValidMemberByIdOrThrow(Long memberId) {
+        List<Member> fetch = queryFactory
+                .select(QMember.member)
+                .from(QMember.member)
+                .where(QMember.member.id.eq(memberId)
+                        .and(QMember.member.deletedAt.isNull())
+                ).fetch();
+
+        if(fetch.isEmpty()) {
+            throw new MemberException(NOT_FOUND_USER);
+        }
+
+        return fetch.get(0);
+    }
+}

--- a/layer-external/src/main/java/org/layer/global/exception/AuthExceptionType.java
+++ b/layer-external/src/main/java/org/layer/global/exception/AuthExceptionType.java
@@ -11,7 +11,8 @@ public enum AuthExceptionType implements ExceptionType {
 	/**
 	 * 400
 	 */
-	FAIL_TO_AUTH(HttpStatus.BAD_REQUEST, "인증에 실패했습니다.");
+	FAIL_TO_AUTH(HttpStatus.BAD_REQUEST, "인증에 실패했습니다."),
+	DUPLICATED_SIGN_UP_REQUEST(HttpStatus.BAD_REQUEST, "중복된 회원 가입 요청입니다. (다른 요청이 이미 처리 중)");
 
 	private final HttpStatus status;
 	private final String message;


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [ ] docs 작업, swagger 작업
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
**1. [엔티티, DB 수정] Member 엔티티에서 socialType, socialId 복합 유니크 제약 삭제**
탈퇴 후 같은 회원이 같은 소셜로그인 방식으로 재가입 가능하도록 해당 제약 조건을 삭제했습니다.
dev, prod DB에는 아직 적용돼있지 않으며 배포 시점에 반영하겠습니다.


**2. MemberRepository 구조 리팩토링과 멤버를 조회하는 메서드 수정**
- 잘못 구현 되어 있던 멤버 조회 메서드를 수정하였습니다. (소프트 딜리트이기에 deletedAt이 null인 것만 조회되어야 하는데, 해당 조건이 누락되어 있었음)
- 리포지토리 구조를 MemberRepository, MemberCustomRepository, MemberRepositoryImpl 구조로 리팩토링했습니다. 더 좋은 구조가 있다면 추천해주셔도 좋습니다!
현재 구조:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/29d25e47-829f-4563-a980-46047167968d" />



**3. 회원가입, 탈퇴를 테스트하는 MemberService, AuthService 테스트 코드 추가** 
- MemberServiceTest: 탈퇴 후 조회되지 않음을 테스트(soft delete가 제대로 되는지)
- MemberServiceTest: 탈퇴 후 재가입 테스트
- AuthServiceTest: 동시 회원가입 호출 시 1번만 처리됨을 테스트



## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부

## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #336 
