### PR TITLE
Add layer-event module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,3 +229,11 @@ project(":layer-admin") {
     }
 
 }
+project(":layer-event") {
+    bootJar.enabled = false
+    jar.enabled = true
+
+    dependencies {
+        implementation project(path: ':layer-common')
+    }
+}

--- a/layer-event/src/main/java/org/layer/event/SampleEvent.java
+++ b/layer-event/src/main/java/org/layer/event/SampleEvent.java
@@ -1,0 +1,10 @@
+package org.layer.event;
+
+/**
+ * Simple event used for testing the layer-event module.
+ */
+public record SampleEvent(String message) {
+    public static SampleEvent of(String message) {
+        return new SampleEvent(message);
+    }
+}

--- a/layer-event/src/test/java/org/layer/event/SampleEventTest.java
+++ b/layer-event/src/test/java/org/layer/event/SampleEventTest.java
@@ -1,0 +1,14 @@
+package org.layer.event;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class SampleEventTest {
+
+    @Test
+    void factoryMethodCreatesEvent() {
+        SampleEvent event = SampleEvent.of("hello");
+        assertEquals("hello", event.message());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,3 +6,4 @@ include 'layer-external'
 include 'layer-batch'
 include 'layer-admin'
 
+include 'layer-event'


### PR DESCRIPTION
## Summary
- create new module `layer-event`
- register module in settings
- configure project block in Gradle build
- provide simple SampleEvent and test

## Testing
- `gradle test --offline -q` *(fails: Plugin [id: 'org.springframework.boot'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511714332c83219601d3a6843311cb