### PR TITLE
[admin] feat: 작성 화면에서 머무는 평균 체류 시간 저장 로직 구현

### DIFF
--- a/layer-admin/src/main/java/org/layer/admin/retrospect/entity/AdminRetrospectAnswerHistory.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/entity/AdminRetrospectAnswerHistory.java
@@ -1,0 +1,61 @@
+package org.layer.admin.retrospect.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AdminRetrospectAnswerHistory {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull
+	private LocalDateTime eventTime;
+
+	@NotNull
+	private Long memberId;
+
+	@NotNull
+	private String eventId;
+
+	@NotNull
+	private Long spaceId;
+
+	@NotNull
+	private Long retrospectId;
+
+	private LocalDateTime answerStartTime;
+
+	private LocalDateTime answerEndTime;
+
+	private String answerContent;
+
+	public void updateRetrospectCompleted (LocalDateTime answerEndTime, String answerContent) {
+		this.answerEndTime = answerEndTime;
+		this.answerContent = answerContent;
+	}
+
+	@Builder
+	private AdminRetrospectAnswerHistory(LocalDateTime eventTime, Long memberId, String eventId, Long spaceId,
+		Long retrospectId, LocalDateTime answerStartTime, LocalDateTime answerEndTime, String answerContent) {
+		this.eventTime = eventTime;
+		this.memberId = memberId;
+		this.eventId = eventId;
+		this.spaceId = spaceId;
+		this.retrospectId = retrospectId;
+		this.answerStartTime = answerStartTime;
+		this.answerEndTime = answerEndTime;
+		this.answerContent = answerContent;
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/listener/WriteRetrospectEventListener.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/listener/WriteRetrospectEventListener.java
@@ -1,0 +1,25 @@
+package org.layer.admin.retrospect.listener;
+
+import org.layer.admin.retrospect.service.AdminRetrospectService;
+import org.layer.event.retrospect.WriteRetrospectEndEvent;
+import org.layer.event.retrospect.WriteRetrospectStartEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WriteRetrospectEventListener {
+	private final AdminRetrospectService adminRetrospectService;
+
+	@EventListener
+	public void handleWriteRetrospectStart(WriteRetrospectStartEvent event) {
+		adminRetrospectService.saveRetrospectAnswerHistory(event);
+	}
+
+	@EventListener
+	public void handleWriteRetrospectEnd(WriteRetrospectEndEvent event) {
+		adminRetrospectService.updateRetrospectAnswerHistory(event);
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/repository/AdminRetrospectRepository.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/repository/AdminRetrospectRepository.java
@@ -1,0 +1,17 @@
+package org.layer.admin.retrospect.repository;
+
+
+import java.util.Optional;
+
+import org.layer.admin.retrospect.entity.AdminRetrospectAnswerHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface AdminRetrospectRepository extends JpaRepository<AdminRetrospectAnswerHistory, Long> {
+
+	Optional<AdminRetrospectAnswerHistory> findByMemberIdAndSpaceIdAndRetrospectId(
+		@Param("memberId") Long memberId,
+		@Param("spaceId") Long spaceId,
+		@Param("retrospectId") Long retrospectId
+	);
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/service/AdminRetrospectService.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/service/AdminRetrospectService.java
@@ -1,0 +1,61 @@
+package org.layer.admin.retrospect.service;
+
+import static org.springframework.transaction.annotation.Propagation.*;
+
+
+import org.layer.admin.retrospect.entity.AdminRetrospectAnswerHistory;
+import org.layer.admin.retrospect.repository.AdminRetrospectRepository;
+import org.layer.event.retrospect.WriteRetrospectEndEvent;
+import org.layer.event.retrospect.WriteRetrospectStartEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminRetrospectService {
+
+	private final AdminRetrospectRepository adminRetrospectRepository;
+
+	@Transactional(propagation = REQUIRES_NEW)
+	@Async
+	public void saveRetrospectAnswerHistory(WriteRetrospectStartEvent event) {
+		AdminRetrospectAnswerHistory retrospectAnswerHistory = AdminRetrospectAnswerHistory.builder()
+			.eventTime(event.eventTime())
+			.memberId(event.memberId())
+			.eventId(event.eventId())
+			.spaceId(event.spaceId())
+			.retrospectId(event.retrospectId())
+			.answerStartTime(event.eventTime())
+			.build();
+
+		adminRetrospectRepository.save(retrospectAnswerHistory);
+	}
+
+	@Transactional(propagation = REQUIRES_NEW)
+	@Async
+	public void updateRetrospectAnswerHistory(WriteRetrospectEndEvent event) {
+
+		adminRetrospectRepository.findByMemberIdAndSpaceIdAndRetrospectId(event.memberId(), event.spaceId(), event.retrospectId())
+			.ifPresentOrElse(
+				history -> {
+					history.updateRetrospectCompleted(event.eventTime(), event.answerContent());
+					adminRetrospectRepository.save(history);
+				},
+				() -> {
+					AdminRetrospectAnswerHistory retrospectAnswerHistory = AdminRetrospectAnswerHistory.builder()
+						.eventTime(event.eventTime())
+						.memberId(event.memberId())
+						.eventId(event.eventId())
+						.spaceId(event.spaceId())
+						.retrospectId(event.retrospectId())
+						.answerEndTime(event.eventTime())
+						.answerContent(event.answerContent())
+						.build();
+					adminRetrospectRepository.save(retrospectAnswerHistory);
+				}
+			);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.layer.domain.answer.entity.Answers;
 import org.layer.domain.answer.enums.AnswerStatus;
 import org.layer.domain.answer.repository.AnswerRepository;
+import org.layer.domain.common.random.CustomRandom;
+import org.layer.domain.common.time.Time;
 import org.layer.domain.question.controller.dto.response.QuestionGetResponse;
 import org.layer.domain.question.controller.dto.response.QuestionListGetResponse;
 import org.layer.domain.question.entity.Question;
@@ -14,6 +16,8 @@ import org.layer.domain.retrospect.entity.Retrospect;
 import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.layer.domain.space.entity.Team;
 import org.layer.domain.space.repository.MemberSpaceRelationRepository;
+import org.layer.event.retrospect.WriteRetrospectStartEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +31,11 @@ public class QuestionService {
 	private final MemberSpaceRelationRepository memberSpaceRelationRepository;
 	private final RetrospectRepository retrospectRepository;
 	private final AnswerRepository answerRepository;
+
+	private final ApplicationEventPublisher eventPublisher;
+
+	private final Time time;
+	private final CustomRandom random;
 
 	public QuestionListGetResponse getRetrospectQuestions(Long spaceId, Long retrospectId, Long memberId){
 
@@ -48,6 +57,9 @@ public class QuestionService {
 		// 임시 저장 여부 확인
 		Answers answers = new Answers(
 			answerRepository.findAllByRetrospectIdAndMemberIdAndAnswerStatus(retrospectId, memberId, AnswerStatus.TEMPORARY));
+
+		eventPublisher.publishEvent(WriteRetrospectStartEvent.of(random.generateRandomValue(), time.now(),
+			memberId, spaceId, retrospectId));
 
 		return QuestionListGetResponse.of(responses, answers.hasRetrospectAnswer(memberId, retrospectId));
 	}

--- a/layer-api/src/main/java/org/layer/global/exception/GlobalExceptionHandler.java
+++ b/layer-api/src/main/java/org/layer/global/exception/GlobalExceptionHandler.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import org.layer.common.exception.BaseCustomException;
 import org.layer.common.exception.ExceptionResponse;
 import org.layer.common.exception.ExceptionType;
-import org.layer.discord.event.ErrorEvent;
+import org.layer.discord.notifier.ErrorEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
+++ b/layer-api/src/main/java/org/layer/scheduler/MemberActivityScheduler.java
@@ -3,7 +3,7 @@ package org.layer.scheduler;
 import java.time.LocalDateTime;
 
 import org.layer.tmpadmin.cache.MemberActivityCache;
-import org.layer.discord.event.MemberActivityEvent;
+import org.layer.discord.notifier.MemberActivityEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
+++ b/layer-domain/src/main/java/org/layer/domain/answer/entity/Answers.java
@@ -9,7 +9,6 @@ import org.layer.domain.answer.enums.AnswerStatus;
 import org.layer.domain.answer.exception.AnswerException;
 import org.layer.domain.retrospect.entity.WriteStatus;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -78,19 +77,6 @@ public class Answers {
 			.forEach(answer -> answerMembers.add(answer.getMemberId()));
 
 		return answerMembers.size();
-	}
-
-	public List<Long> getWriteMemberIds() {
-		Set<Long> set = new HashSet<>();
-
-		answers.forEach(answer -> {
-			// 임시저장된 회고일 경우 제외
-			if (answer.getAnswerStatus() != AnswerStatus.TEMPORARY) {
-				set.add(answer.getMemberId());
-			}
-		});
-
-		return new ArrayList<>(set);
 	}
 
 	public void validateNoAnswer() {

--- a/layer-event/src/main/java/org/layer/event/retrospect/WriteRetrospectEndEvent.java
+++ b/layer-event/src/main/java/org/layer/event/retrospect/WriteRetrospectEndEvent.java
@@ -1,0 +1,25 @@
+package org.layer.event.retrospect;
+
+import java.time.LocalDateTime;
+
+public record WriteRetrospectEndEvent(
+	String eventId,
+	LocalDateTime eventTime,
+	Long memberId,
+	Long spaceId,
+	Long retrospectId,
+	String answerContent
+) {
+	public static WriteRetrospectEndEvent of(
+		String eventId,
+		LocalDateTime eventTime,
+		Long memberId,
+		Long spaceId,
+		Long retrospectId,
+		String answerContent
+	) {
+		return new WriteRetrospectEndEvent(
+			eventId, eventTime, memberId, spaceId, retrospectId, answerContent
+		);
+	}
+}

--- a/layer-event/src/main/java/org/layer/event/retrospect/WriteRetrospectStartEvent.java
+++ b/layer-event/src/main/java/org/layer/event/retrospect/WriteRetrospectStartEvent.java
@@ -1,0 +1,23 @@
+package org.layer.event.retrospect;
+
+import java.time.LocalDateTime;
+
+public record WriteRetrospectStartEvent(
+	String eventId,
+	LocalDateTime eventTime,
+	Long memberId,
+	Long spaceId,
+	Long retrospectId
+) {
+	public static WriteRetrospectStartEvent of(
+		String eventId,
+		LocalDateTime eventTime,
+		Long memberId,
+		Long spaceId,
+		Long retrospectId
+	) {
+		return new WriteRetrospectStartEvent(
+			eventId, eventTime, memberId, spaceId, retrospectId
+		);
+	}
+}

--- a/layer-external/src/main/java/org/layer/discord/notifier/CreateRetrospectEventNotifier.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/CreateRetrospectEventNotifier.java
@@ -1,6 +1,7 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import org.layer.discord.DiscordAppender;
+import org.layer.event.retrospect.CreateRetrospectEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -10,13 +11,15 @@ import lombok.RequiredArgsConstructor;
 @Component
 @Profile("prod")
 @RequiredArgsConstructor
-public class ErrorEventNotifier {
+public class CreateRetrospectEventNotifier {
+
 	private final DiscordAppender discordAppender;
 
 	@EventListener
-	public void handleSignUpEvent(ErrorEvent event) {
-		discordAppender.createErrorAppend(
-			event.message(),
-			event.stackTrace());
+	public void handleSignUpEvent(CreateRetrospectEvent event) {
+		discordAppender.createRetrospectAppend(
+			event.title(),
+			event.memberId(),
+			event.createdDate());
 	}
 }

--- a/layer-external/src/main/java/org/layer/discord/notifier/CreateSpaceEventNotifier.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/CreateSpaceEventNotifier.java
@@ -1,7 +1,7 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import org.layer.discord.DiscordAppender;
-import org.layer.event.member.SignUpEvent;
+import org.layer.event.space.CreateSpaceEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -11,13 +11,14 @@ import lombok.RequiredArgsConstructor;
 @Component
 @Profile("prod")
 @RequiredArgsConstructor
-public class SignUpEventNotifier {
+public class CreateSpaceEventNotifier {
+
 	private final DiscordAppender discordAppender;
 
 	@EventListener
-	public void handleSignUpEvent(SignUpEvent event) {
-		discordAppender.createMember(
-			event.name(),
+	public void handleSignUpEvent(CreateSpaceEvent event) {
+		discordAppender.createSpaceAppend(
+			event.title(),
 			event.memberId(),
 			event.eventTime());
 	}

--- a/layer-external/src/main/java/org/layer/discord/notifier/ErrorEvent.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/ErrorEvent.java
@@ -1,4 +1,4 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import java.time.LocalDateTime;
 

--- a/layer-external/src/main/java/org/layer/discord/notifier/ErrorEventNotifier.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/ErrorEventNotifier.java
@@ -1,7 +1,6 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import org.layer.discord.DiscordAppender;
-import org.layer.event.space.CreateSpaceEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -11,15 +10,13 @@ import lombok.RequiredArgsConstructor;
 @Component
 @Profile("prod")
 @RequiredArgsConstructor
-public class CreateSpaceEventNotifier {
-
+public class ErrorEventNotifier {
 	private final DiscordAppender discordAppender;
 
 	@EventListener
-	public void handleSignUpEvent(CreateSpaceEvent event) {
-		discordAppender.createSpaceAppend(
-			event.title(),
-			event.memberId(),
-			event.eventTime());
+	public void handleSignUpEvent(ErrorEvent event) {
+		discordAppender.createErrorAppend(
+			event.message(),
+			event.stackTrace());
 	}
 }

--- a/layer-external/src/main/java/org/layer/discord/notifier/MemberActivityEvent.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/MemberActivityEvent.java
@@ -1,4 +1,4 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import java.util.Map;
 

--- a/layer-external/src/main/java/org/layer/discord/notifier/MemberActivityEventNotifier.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/MemberActivityEventNotifier.java
@@ -1,7 +1,6 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import org.layer.discord.DiscordAppender;
-import org.layer.event.retrospect.CreateRetrospectEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -11,15 +10,11 @@ import lombok.RequiredArgsConstructor;
 @Component
 @Profile("prod")
 @RequiredArgsConstructor
-public class CreateRetrospectEventNotifier {
-
+public class MemberActivityEventNotifier {
 	private final DiscordAppender discordAppender;
 
 	@EventListener
-	public void handleSignUpEvent(CreateRetrospectEvent event) {
-		discordAppender.createRetrospectAppend(
-			event.title(),
-			event.memberId(),
-			event.createdDate());
+	public void handleSignUpEvent(MemberActivityEvent event) {
+		discordAppender.aggregateMemberActivity(event.activities());
 	}
 }

--- a/layer-external/src/main/java/org/layer/discord/notifier/SignUpEventNotifier.java
+++ b/layer-external/src/main/java/org/layer/discord/notifier/SignUpEventNotifier.java
@@ -1,6 +1,7 @@
-package org.layer.discord.event;
+package org.layer.discord.notifier;
 
 import org.layer.discord.DiscordAppender;
+import org.layer.event.member.SignUpEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -10,11 +11,14 @@ import lombok.RequiredArgsConstructor;
 @Component
 @Profile("prod")
 @RequiredArgsConstructor
-public class MemberActivityEventNotifier {
+public class SignUpEventNotifier {
 	private final DiscordAppender discordAppender;
 
 	@EventListener
-	public void handleSignUpEvent(MemberActivityEvent event) {
-		discordAppender.aggregateMemberActivity(event.activities());
+	public void handleSignUpEvent(SignUpEvent event) {
+		discordAppender.createMember(
+			event.name(),
+			event.memberId(),
+			event.eventTime());
 	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현 및 수정
- [ ] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 작성 화면에서 머무는 평균 체류 시간 저장 로직 구현 했습니다.
- 시작시간 데이터와 종료시간 데이터의 라이프사이클이 다르지만 하나의 엔티티로 있어 응집도 측면에서 아쉬움을 느꼈습니다.
- 하지만 해당 데이터들이 절대 수정되지 않는 어드민 데이터이며, 앞으로 사용될 유스케이스가 모두 함께 조회되어야 하기 때문에 하나의 엔티티에 뒀습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #375 
