### PR TITLE
[admin] feat: 하나의 스페이스 생성 후 누적되는 회고 수 평균 조회 구현

### DIFF
--- a/layer-admin/src/main/java/org/layer/admin/retrospect/controller/AdminRetrospectController.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/controller/AdminRetrospectController.java
@@ -3,6 +3,7 @@ package org.layer.admin.retrospect.controller;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.layer.admin.retrospect.controller.dto.CumulativeRetrospectCountResponse;
 import org.layer.admin.retrospect.controller.dto.MeaningfulRetrospectMemberResponse;
 import org.layer.admin.retrospect.controller.dto.RetrospectRetentionResponse;
 import org.layer.admin.retrospect.controller.dto.RetrospectStayTimeResponse;
@@ -50,5 +51,16 @@ public class AdminRetrospectController {
 		@RequestParam(name = "endDate") LocalDateTime endDate) {
 
 		return adminRetrospectService.getRetrospectRetention(startDate, endDate);
+	}
+
+	@GetMapping("/admin/retrospect/cumulative-count")
+	public ResponseEntity<CumulativeRetrospectCountResponse> getCumulativeRetrospectCount(
+		@RequestParam(name = "startDate") LocalDateTime startDate,
+		@RequestParam(name = "endDate") LocalDateTime endDate) {
+
+		CumulativeRetrospectCountResponse response = adminRetrospectService.getCumulativeRetrospectCount(
+			startDate, endDate);
+
+		return ResponseEntity.ok().body(response);
 	}
 }

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/controller/dto/CumulativeRetrospectCountResponse.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/controller/dto/CumulativeRetrospectCountResponse.java
@@ -1,0 +1,6 @@
+package org.layer.admin.retrospect.controller.dto;
+
+public record CumulativeRetrospectCountResponse(
+	long averageCumulativeCount
+) {
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/repository/AdminRetrospectRepository.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/repository/AdminRetrospectRepository.java
@@ -4,10 +4,23 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.layer.admin.retrospect.entity.AdminRetrospectHistory;
+import org.layer.admin.retrospect.repository.dto.SpaceRetrospectCountDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AdminRetrospectRepository extends JpaRepository<AdminRetrospectHistory, Long> {
 	List<AdminRetrospectHistory> findAllByEventTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
 
 	List<AdminRetrospectHistory> findAllByEventTimeBefore(LocalDateTime time);
+
+	@Query("SELECT new org.layer.admin.retrospect.repository.dto.SpaceRetrospectCountDto(m.spaceId, COUNT(m)) " +
+		"FROM AdminRetrospectHistory m " +
+		"WHERE m.eventTime BETWEEN :startTime AND :endTime " +
+		"GROUP BY m.spaceId ")
+	List<SpaceRetrospectCountDto> findRetrospectCountGroupedBySpaceWithPeriod(
+		@Param("startTime") LocalDateTime startTime,
+		@Param("endTime") LocalDateTime endTime
+	);
+
 }

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/repository/dto/SpaceRetrospectCountDto.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/repository/dto/SpaceRetrospectCountDto.java
@@ -1,0 +1,11 @@
+package org.layer.admin.retrospect.repository.dto;
+
+public record SpaceRetrospectCountDto(
+	Long spaceId,
+	long count
+) {
+	public SpaceRetrospectCountDto(Long spaceId, long count) {
+		this.spaceId = spaceId;
+		this.count = count;
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/space/repository/AdminSpaceRepository.java
+++ b/layer-admin/src/main/java/org/layer/admin/space/repository/AdminSpaceRepository.java
@@ -20,4 +20,10 @@ public interface AdminSpaceRepository
 		@Param("startTime") LocalDateTime startTime,
 		@Param("endTime") LocalDateTime endTime
 	);
+
+	@Query("SELECT COUNT(a) FROM AdminSpaceHistory a " +
+		"WHERE a.eventTime BETWEEN :startTime AND :endTime")
+	Long countAllByEventTimeBetween(
+		@Param("startTime") LocalDateTime startTime,
+		@Param("endTime") LocalDateTime endTime);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현 및 수정
- [ ] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 하나의 스페이스 생성 후 누적되는 회고 수 평균 조회 기능을 구현했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #399 
