### PR TITLE
fix: spaceId 주입 오류 및 마감기한 설정 오류 해결

### DIFF
--- a/layer-admin/src/main/java/org/layer/admin/space/service/AdminSpaceService.java
+++ b/layer-admin/src/main/java/org/layer/admin/space/service/AdminSpaceService.java
@@ -59,6 +59,7 @@ public class AdminSpaceService {
 			.eventTime(event.eventTime())
 			.memberId(event.memberId())
 			.category(AdminSpaceCategory.from(event.category()))
+			.spaceId(event.spaceId())
 			.build();
 
 		adminSpaceRepository.save(spaceHistory);

--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -105,13 +105,8 @@ public class AnswerService {
 
 		// 마지막 답변인 경우 -> ai 분석 실행
 		if (answers.getWriteCount(retrospectId) == team.getTeamMemberCount()) {
-			retrospect.completeRetrospectAndStartAnalysis();
-
-			if (!retrospect.hasDeadLine()) {
-                retrospect.updateDeadLine(time.now());
-			}
+			retrospect.completeRetrospectAndStartAnalysis(time.now());
 			retrospectRepository.save(retrospect);
-
 			eventPublisher.publishEvent(AIAnalyzeStartEvent.of(retrospectId));
 		}
 

--- a/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/retrospect/service/RetrospectService.java
@@ -196,13 +196,11 @@ public class RetrospectService {
 
 		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
 
-		retrospect.completeRetrospectAndStartAnalysis();
+		retrospect.completeRetrospectAndStartAnalysis(time.now());
 		if (retrospect.getAnalysisStatus().equals(AnalysisStatus.DONE)) {
-			// 비정상 케이스
 			log.error("비정상적인 오류입니다.");
 			return;
 		}
-
 		retrospectRepository.save(retrospect);
 
 		// 회고 ai 분석 시작

--- a/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
+++ b/layer-api/src/main/java/org/layer/domain/space/service/SpaceService.java
@@ -110,6 +110,7 @@ public class SpaceService {
 			random.generateRandomValue(),
 			memberId,
 			time.now(),
+			space.getId(),
 			space.getName(),
 			space.getCategory().name()
 		));

--- a/layer-api/src/test/java/org/layer/domain/answer/service/AnswerServiceTest.java
+++ b/layer-api/src/test/java/org/layer/domain/answer/service/AnswerServiceTest.java
@@ -2,11 +2,17 @@ package org.layer.domain.answer.service;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.assertj.core.api.Assertions;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.layer.domain.answer.controller.dto.request.AnswerCreateRequest;
+import org.layer.domain.answer.controller.dto.request.AnswerListCreateRequest;
 import org.layer.domain.answer.controller.dto.response.AnswerListGetResponse;
+import org.layer.domain.retrospect.entity.Retrospect;
+import org.layer.domain.retrospect.entity.RetrospectStatus;
+import org.layer.domain.retrospect.repository.RetrospectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -21,6 +27,9 @@ class AnswerServiceTest {
 
 	@Autowired
 	private AnswerService answerService;
+
+	@Autowired
+	private RetrospectRepository retrospectRepository;
 
 	@Nested
 	@SqlGroup({
@@ -43,15 +52,59 @@ class AnswerServiceTest {
 
 			// then
 			assertThat(analyzeAnswers).isNotNull();
-			assertThat(analyzeAnswers.questions()).hasSize(2);
+			assertThat(analyzeAnswers.questions()).hasSize(4);
 			assertThat(analyzeAnswers.questions().get(0).questionContent()).isEqualTo("질문1");
-			assertThat(analyzeAnswers.questions().get(0).answers().get(0).answerContent()).isEqualTo("회고답변 1");
-			assertThat(analyzeAnswers.questions().get(1).answers().get(0).answerContent()).isEqualTo("회고답변 2");
+			assertThat(analyzeAnswers.questions().get(0).answers().get(0).answerContent()).isEqualTo("5");
+			assertThat(analyzeAnswers.questions().get(1).answers().get(0).answerContent()).isEqualTo("80");
 
 			assertThat(analyzeAnswers.individuals()).hasSize(1);
 			assertThat(analyzeAnswers.individuals().get(0).name()).isEqualTo("홍길동");
-			assertThat(analyzeAnswers.individuals().get(0).answers().get(0).answerContent()).isEqualTo("회고답변 1");
-			assertThat(analyzeAnswers.individuals().get(0).answers().get(1).answerContent()).isEqualTo("회고답변 2");
+			assertThat(analyzeAnswers.individuals().get(0).answers().get(0).answerContent()).isEqualTo("5");
+			assertThat(analyzeAnswers.individuals().get(0).answers().get(1).answerContent()).isEqualTo("80");
+		}
+	}
+
+	@Nested
+	@SqlGroup({
+		@Sql(value = "/sql/answer-service-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+		@Sql(value = "/sql/delete-all-test-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+
+	})
+	class 회고_작성 {
+		@Test
+		@DisplayName("특정 회고 작성 후에 작성된 답변이 팀 인원 수와 같다면, 회고 마감 상태로 변경된다."
+			+ "또한 만약 마감기한이 미지정이라면, 마감기한이 현재 시간으로 설정된다.")
+		void createAnswerTest_1() {
+			// given
+			Long spaceId = 1L;
+			Long retrospectId = 1L;
+			Long memberId = 2L;
+
+			AnswerCreateRequest request1 = new AnswerCreateRequest(
+				1L, "number", "5"
+			);
+
+			AnswerCreateRequest request2 = new AnswerCreateRequest(
+				2L, "range", "100"
+			);
+
+			AnswerCreateRequest request3 = new AnswerCreateRequest(
+				3L, "plain_text", "답변1"
+			);
+
+			AnswerCreateRequest request4 = new AnswerCreateRequest(
+				4L, "plain_text", "답변2"
+			);
+
+			// when
+			answerService.create(new AnswerListCreateRequest(
+				List.of(request1, request2, request3, request4), false),
+				spaceId, retrospectId, memberId);
+
+			// then
+			Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
+			assertThat(retrospect.getRetrospectStatus()).isEqualTo(RetrospectStatus.DONE);
+			assertThat(retrospect.getDeadline()).isNotNull();
 		}
 	}
 

--- a/layer-api/src/test/resources/sql/answer-service-test-data.sql
+++ b/layer-api/src/test/resources/sql/answer-service-test-data.sql
@@ -12,14 +12,24 @@ VALUES
     ('2024-12-27 00:00:00', '2024-12-27 00:00:00', 1, 1),
     ('2024-12-27 00:00:00', '2024-12-27 00:00:00', 2, 1);
 
-INSERT INTO question (created_at, updated_at, content, form_id, question_order, question_owner, question_type, retrospect_id)
+INSERT INTO retrospect (id, created_at, updated_at, space_id, title, introduction, retrospect_status,
+                        analysis_status, deadline)
 VALUES
-    ('2024-12-27 00:00:00', '2024-12-27 00:00:00', '질문1', 1, 1, 'INDIVIDUAL', 'PLAIN_TEXT', 1),
-    ('2024-12-27 00:00:00', '2024-12-27 00:00:00', '질문2', 1, 2, 'TEAM', 'PLAIN_TEXT', 1);
+    (1, '2024-12-27 00:00:00', '2024-12-27 00:00:00', 1, '2024년 12월 회고', '2024년 12월 회고를 위한 공간입니다.', 'PROCEEDING',
+     'NOT_STARTED', null);
 
-INSERT INTO answer (created_at, updated_at, answer_status, content, member_id, question_id, retrospect_id)
+INSERT INTO question (id, created_at, updated_at, content, form_id, question_order, question_owner, question_type, retrospect_id)
 VALUES
-    ('2024-12-27 00:00:00', '2024-12-27 00:00:00', 'DONE', '회고답변 1', 1, 1, 1),
-    ('2024-12-27 00:00:00', '2024-12-27 00:00:00', 'TEMPORARY', '회고임시답변', 1, 2, 1),
-    ('2024-12-27 00:00:00', '2024-12-27 00:00:00', 'DONE', '회고답변 2', 1, 2, 1);
+    (1, '2024-12-27 00:00:00', '2024-12-27 00:00:00', '질문1', 1, 1, 'TEAM', 'NUMBER', 1),
+    (2, '2024-12-27 00:00:00', '2024-12-27 00:00:00', '질문2', 1, 2, 'TEAM', 'RANGER', 1),
+    (3, '2024-12-27 00:00:00', '2024-12-27 00:00:00', '질문3', 1, 3, 'TEAM', 'PLAIN_TEXT', 1),
+    (4, '2024-12-27 00:00:00', '2024-12-27 00:00:00', '질문4', 1, 4, 'TEAM', 'PLAIN_TEXT', 1);
+
+INSERT INTO answer (id, created_at, updated_at, answer_status, content, member_id, question_id, retrospect_id)
+VALUES
+    (1, '2024-12-27 00:00:00', '2024-12-27 00:00:00', 'DONE', '5', 1, 1, 1),
+    (2, '2024-12-27 00:00:00', '2024-12-27 00:00:00', 'TEMPORARY', '80', 1, 2, 1),
+    (3, '2024-12-27 00:00:00', '2024-12-27 00:00:00', 'DONE', '80', 1, 2, 1),
+    (4, '2024-12-27 00:00:00', '2024-12-27 00:00:00', 'DONE', '답변1', 1, 3, 1),
+    (5, '2024-12-27 00:00:00', '2024-12-27 00:00:00', 'DONE', '답변2', 1, 4, 1);
 

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -87,9 +87,13 @@ public class Retrospect extends BaseTimeEntity {
 		this.deadline = deadline;
 	}
 
-	public void completeRetrospectAndStartAnalysis(){
+	public void completeRetrospectAndStartAnalysis(LocalDateTime now){
 		updateRetrospectStatus(RetrospectStatus.DONE);
 		updateAnalysisStatus(AnalysisStatus.PROCEEDING);
+
+		if(this.deadline == null) {
+			this.deadline = now;
+		}
 	}
 
 	public void updateRetrospectStatus(RetrospectStatus retrospectStatus) {

--- a/layer-event/src/main/java/org/layer/event/space/CreateSpaceEvent.java
+++ b/layer-event/src/main/java/org/layer/event/space/CreateSpaceEvent.java
@@ -8,10 +8,18 @@ public record CreateSpaceEvent(
 	String eventId,
 	Long memberId,
 	LocalDateTime eventTime,
+	Long spaceId,
 	String title,
 	String category
 ) implements BaseEvent {
-	public static CreateSpaceEvent of(String eventId, Long memberId, LocalDateTime eventTime, String title, String category) {
-		return new CreateSpaceEvent(eventId, memberId, eventTime, title, category);
+	public static CreateSpaceEvent of(
+		String eventId,
+		Long memberId,
+		LocalDateTime eventTime,
+		Long spaceId,
+		String title,
+		String category
+	) {
+		return new CreateSpaceEvent(eventId, memberId, eventTime, spaceId, title, category);
 	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현 및 수정
- [x] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고가 마감된 시점에서는 마감기한이 null 일 수 없다.
- space 생성 이벤트가 발생했을 때, spaceId도 함께 필드값에 주입한다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #4141
