### PR TITLE
feat: 회고 스페이스 목록 데이터 개선

### DIFF
--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceApi.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceApi.java
@@ -35,7 +35,7 @@ public interface SpaceApi {
             )
     }
     )
-    ResponseEntity<SpaceResponse.SpacePage> getMySpaceList(@MemberId Long memberId, @ModelAttribute @Validated SpaceRequest.GetSpaceRequest getSpaceRequest);
+    ResponseEntity<SpaceResponse.SpacePage> getMySpaces(@MemberId Long memberId, @ModelAttribute @Validated SpaceRequest.GetSpaceRequest getSpaceRequest);
 
     @Operation(summary = "스페이스 생성하기", method = "POST", description = """
             스페이스를 생성합니다. <br />

--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
@@ -24,7 +24,7 @@ public class SpaceController implements SpaceApi {
     @Override
     @GetMapping("/list")
     public ResponseEntity<SpaceResponse.SpacePage> getMySpaceList(@MemberId Long memberId, @ModelAttribute @Valid SpaceRequest.GetSpaceRequest getSpaceRequest) {
-        var response = spaceService.getSpaceListFromMemberId(memberId, getSpaceRequest);
+        var response = spaceService.getMySpaces(memberId, getSpaceRequest);
         return ResponseEntity.ok(response);
     }
 

--- a/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/SpaceController.java
@@ -23,7 +23,7 @@ public class SpaceController implements SpaceApi {
 
     @Override
     @GetMapping("/list")
-    public ResponseEntity<SpaceResponse.SpacePage> getMySpaceList(@MemberId Long memberId, @ModelAttribute @Valid SpaceRequest.GetSpaceRequest getSpaceRequest) {
+    public ResponseEntity<SpaceResponse.SpacePage> getMySpaces(@MemberId Long memberId, @ModelAttribute @Valid SpaceRequest.GetSpaceRequest getSpaceRequest) {
         var response = spaceService.getMySpaces(memberId, getSpaceRequest);
         return ResponseEntity.ok(response);
     }

--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceRequest.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceRequest.java
@@ -68,24 +68,15 @@ public class SpaceRequest {
     @Schema(description = "내가 속한 스페이스 조회")
     public record GetSpaceRequest(
             @Schema(description = "커서 아이디")
-            Long cursorId,
+            long cursorId,
 
             @Schema(description = "조회하고자 하는 스페이스 타입")
-            Optional<SpaceCategory> category,
+            SpaceCategory category,
 
             @Schema(description = "페이지 사이즈", defaultValue = "1")
             int pageSize
 
     ) {
-        public GetSpaceRequest {
-            if (pageSize <= 0) {
-                pageSize = 1;
-            }
-            if (cursorId == null) {
-                cursorId = 0L;
-            }
-        }
-
     }
 
     @Schema(description = "스페이스 떠나기")

--- a/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
+++ b/layer-api/src/main/java/org/layer/domain/space/controller/dto/SpaceResponse.java
@@ -20,121 +20,161 @@ import java.util.List;
 @Slf4j
 public class SpaceResponse {
 
-    @Builder
-    @Schema(description = "스페이스 정보 응답")
-    public record SpaceWithMemberCountInfo(
-            @Schema(description = "스페이스 ID")
-            @NotNull
-            Long id,
-            @Schema(description = "프로젝트 유형 카테고리")
-            @NotNull
-            SpaceCategory category,
-            @Schema(description = "진행중인 프로젝트 유형")
-            @NotNull
-            List<SpaceField> fieldList,
-            @Schema(description = "이름")
-            @NotNull
-            String name,
-            @Schema(description = "공간 설명")
-            String introduction,
-            @Schema(description = "설정된 회고 폼 아이디")
-            Long formId,
-            @Schema(description = "설정된 회고 폼 태그")
-            String formTag,
-            @Schema(description = "소속된 회원 수")
-            Long memberCount,
-            @Schema(description = "스페이스 배너 이미지")
-            String bannerUrl,
-            @Schema(description = "스페이스 생성 일자")
-            LocalDateTime createdAt,
-            @Schema(description = "스페이스 리더 아이디")
-            Leader leader
-    ) {
-        public static SpaceWithMemberCountInfo toResponse(SpaceWithMemberCount space) {
+	@Builder
+	@Schema(description = "스페이스 정보 응답")
+	public record SpaceWithMemberCountInfo(
+		@Schema(description = "스페이스 ID")
+		@NotNull
+		Long id,
+		@Schema(description = "프로젝트 유형 카테고리")
+		@NotNull
+		SpaceCategory category,
+		@Schema(description = "진행중인 프로젝트 유형")
+		@NotNull
+		List<SpaceField> fieldList,
+		@Schema(description = "이름")
+		@NotNull
+		String name,
+		@Schema(description = "공간 설명")
+		String introduction,
+		@Schema(description = "설정된 회고 폼 아이디")
+		Long formId,
+		@Schema(description = "설정된 회고 폼 태그")
+		String formTag,
+		@Schema(description = "소속된 회원 수")
+		Long memberCount,
+		@Schema(description = "스페이스 배너 이미지")
+		String bannerUrl,
+		@Schema(description = "스페이스 생성 일자")
+		LocalDateTime createdAt,
+		@Schema(description = "스페이스 리더 아이디")
+		Leader leader
 
-            return SpaceWithMemberCountInfo.builder()
-                .id(space.getId())
-                .category(space.getCategory())
-                .fieldList(space.getFieldList())
-                .name(space.getName())
-                .introduction(space.getIntroduction())
-                .formId(space.getFormId())
-                .formTag(space.getFormTag())
-                .memberCount(space.getMemberCount())
-                .bannerUrl(space.getBannerUrl())
-                .createdAt(space.getCreatedAt())
-                .leader(space.getLeader())
-                .build();
-        }
+	) {
+		public static SpaceWithMemberCountInfo of(Space space, Form form, Long memberCount, Leader leader) {
+			String formTag = form != null ? form.getFormTag().getTag() : null;
 
-        public static SpaceWithMemberCountInfo of(Space space, Form form, Long memberCount, Leader leader) {
-            String formTag = form != null ? form.getFormTag().getTag() : null;
+			return SpaceWithMemberCountInfo.builder()
+				.id(space.getId())
+				.category(space.getCategory())
+				.fieldList(space.getFieldList())
+				.name(space.getName())
+				.introduction(space.getIntroduction())
+				.formId(space.getFormId())
+				.formTag(formTag)
+				.memberCount(memberCount)
+				.bannerUrl(space.getBannerUrl())
+				.createdAt(space.getCreatedAt())
+				.leader(leader)
+				.build();
+		}
+	}
 
-            return SpaceWithMemberCountInfo.builder()
-                .id(space.getId())
-                .category(space.getCategory())
-                .fieldList(space.getFieldList())
-                .name(space.getName())
-                .introduction(space.getIntroduction())
-                .formId(space.getFormId())
-                .formTag(formTag)
-                .memberCount(memberCount)
-                .bannerUrl(space.getBannerUrl())
-                .createdAt(space.getCreatedAt())
-                .leader(leader)
-                .build();
-        }
-    }
+	@Builder
+	@Schema(description = "스페이스 정보 응답 (회원 수 및 회고 수 포함)")
+	public record SpaceWithMemberCountAndRetrospectCount(
+		@Schema(description = "스페이스 ID")
+		@NotNull
+		Long id,
+		@Schema(description = "프로젝트 유형 카테고리")
+		@NotNull
+		SpaceCategory category,
+		@Schema(description = "진행중인 프로젝트 유형")
+		@NotNull
+		List<SpaceField> fieldList,
+		@Schema(description = "이름")
+		@NotNull
+		String name,
+		@Schema(description = "공간 설명")
+		String introduction,
+		@Schema(description = "설정된 회고 폼 아이디")
+		Long formId,
+		@Schema(description = "설정된 회고 폼 태그")
+		String formTag,
+		@Schema(description = "소속된 회원 수")
+		Long memberCount,
+		@Schema(description = "스페이스 배너 이미지")
+		String bannerUrl,
+		@Schema(description = "스페이스 생성 일자")
+		LocalDateTime createdAt,
+		@Schema(description = "스페이스 리더 아이디")
+		Leader leader,
+		@Schema(description = "누적 회고 수")
+		Long retrospectCount,
+		@Schema(description = "진행중인 회고 수")
+		Long proceedingRetrospectCount
 
-    @Builder
-    @Schema
-    public record SpacePage(
-            @Schema
-            List<SpaceWithMemberCountInfo> data,
+	) {
+		public static SpaceWithMemberCountAndRetrospectCount toResponse(SpaceWithMemberCount space, Long retrospectCount,
+			Long proceedingRetrospectCount) {
 
-            @Schema
-            Meta meta
-    ) {
+			return SpaceWithMemberCountAndRetrospectCount.builder()
+				.id(space.getId())
+				.category(space.getCategory())
+				.fieldList(space.getFieldList())
+				.name(space.getName())
+				.introduction(space.getIntroduction())
+				.formId(space.getFormId())
+				.formTag(space.getFormTag())
+				.memberCount(space.getMemberCount())
+				.bannerUrl(space.getBannerUrl())
+				.createdAt(space.getCreatedAt())
+				.leader(space.getLeader())
+				.retrospectCount(retrospectCount)
+				.proceedingRetrospectCount(proceedingRetrospectCount)
+				.build();
+		}
+	}
 
-        public static SpacePage toResponse(List<SpaceWithMemberCountInfo> spaceInfo, Meta meta) {
-            return SpacePage.builder().data(spaceInfo).meta(meta).build();
-        }
-    }
+	@Builder
+	@Schema
+	public record SpacePage(
+		@Schema
+		List<SpaceWithMemberCountAndRetrospectCount> data,
 
-    @Builder
-    @Schema
-    public record SpaceCreateResponse(
-            @Schema(title = "생성된 스페이스 아이디", description = """
-                                        
-                    생성 완료된 스페이스의 아이디
-                                        
-                    """)
-            Long spaceId
-    ) {
-    }
+		@Schema
+		Meta meta
+	) {
 
-    @Builder
-    @Schema
-    public record SpaceMemberResponse(
-            @Schema(title = "맴버 아이디")
-            Long id,
-            @Schema(title = "멤버 프로필 사진")
-            String avatar,
+		public static SpacePage toResponse(List<SpaceWithMemberCountAndRetrospectCount> spaceInfo, Meta meta) {
+			return SpacePage.builder().data(spaceInfo).meta(meta).build();
+		}
+	}
 
-            @Schema(title = "멤버 이름")
-            String name,
+	@Builder
+	@Schema
+	public record SpaceCreateResponse(
+		@Schema(title = "생성된 스페이스 아이디", description = """
+			                    
+			생성 완료된 스페이스의 아이디
+			                    
+			""")
+		Long spaceId
+	) {
+	}
 
-            @Schema(title = "스페이스 리더 여부")
-            Boolean isLeader
-    ) {
-        public static SpaceMemberResponse of(Member member, boolean isLeader) {
-            return SpaceMemberResponse
-                .builder()
-                .id(member.getId())
-                .name(member.getName())
-                .avatar(member.getProfileImageUrl())
-                .isLeader(isLeader)
-                .build();
-        }
-    }
+	@Builder
+	@Schema
+	public record SpaceMemberResponse(
+		@Schema(title = "맴버 아이디")
+		Long id,
+		@Schema(title = "멤버 프로필 사진")
+		String avatar,
+
+		@Schema(title = "멤버 이름")
+		String name,
+
+		@Schema(title = "스페이스 리더 여부")
+		Boolean isLeader
+	) {
+		public static SpaceMemberResponse of(Member member, boolean isLeader) {
+			return SpaceMemberResponse
+				.builder()
+				.id(member.getId())
+				.name(member.getName())
+				.avatar(member.getProfileImageUrl())
+				.isLeader(isLeader)
+				.build();
+		}
+	}
 }

--- a/layer-common/src/main/java/org/layer/common/dto/CursorPageReq.java
+++ b/layer-common/src/main/java/org/layer/common/dto/CursorPageReq.java
@@ -1,0 +1,37 @@
+package org.layer.common.dto;
+
+public class CursorPageReq {
+	private final long cursorId;
+	private final int pageSize;
+
+	public CursorPageReq(long cursorId, int pageSize) {
+		if(pageSize <= 0) {
+			pageSize = 1;
+		}
+
+		this.cursorId = cursorId;
+		this.pageSize = pageSize;
+	}
+
+	public boolean isFirstPage() {
+		return cursorId == 0L;
+	}
+
+	public long getCursorId() {
+		return cursorId;
+	}
+
+	/**
+	 * 클라이언트가 요청한 페이지 사이즈
+	 */
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	/**
+	 * 쿼리에 사용할 실제 조회 크기 (hasNext 판단을 위해 +1)
+	 */
+	public int getFetchSize() {
+		return pageSize + 1;
+	}
+}

--- a/layer-common/src/main/java/org/layer/common/dto/CursorPageRes.java
+++ b/layer-common/src/main/java/org/layer/common/dto/CursorPageRes.java
@@ -1,0 +1,33 @@
+package org.layer.common.dto;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class CursorPageRes<T> {
+	private final List<T> data;
+	private final Meta meta;
+
+	public CursorPageRes(List<T> data, int pageSize, Function<T, Long> cursorExtractor) {
+		this.data = data;
+		boolean hasNextPage = data.size() > pageSize;
+
+		if(hasNextPage) {
+			data.remove(data.size() - 1);
+		}
+
+		Long nextCursor = data.isEmpty() ? null : cursorExtractor.apply(data.get(data.size() - 1));
+
+		meta = Meta.builder()
+			.cursor(hasNextPage ? nextCursor : null)
+			.hasNextPage(hasNextPage)
+			.build();
+	}
+
+	public List<T> getData() {
+		return data;
+	}
+
+	public Meta getMeta() {
+		return meta;
+	}
+}

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithMemberCount.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithMemberCount.java
@@ -1,7 +1,6 @@
 package org.layer.domain.space.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.layer.domain.form.enums.FormTag;
@@ -20,19 +19,14 @@ public class SpaceWithMemberCount {
     private Long id;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    @NotNull
     private SpaceCategory category;
-    @NotNull
     private List<SpaceField> fieldList;
-    @NotNull
     private String name;
     private String introduction;
-    @NotNull
     private Leader leader;
     private Long formId;
     private String formTag;
     private Long memberCount;
-
     private String bannerUrl;
 
     @QueryProjection

--- a/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithRetrospectCount.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/dto/SpaceWithRetrospectCount.java
@@ -1,0 +1,7 @@
+package org.layer.domain.space.dto;
+
+public interface SpaceWithRetrospectCount {
+	Long getId();
+	Long getRetrospectCount();
+	Long getProceedingRetrospectCount();
+}

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceCustomRepository.java
@@ -1,5 +1,7 @@
 package org.layer.domain.space.repository;
 
+import org.layer.common.dto.CursorPageReq;
+import org.layer.common.dto.CursorPageRes;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
 import org.layer.domain.space.entity.SpaceCategory;
 
@@ -10,9 +12,10 @@ public interface SpaceCustomRepository {
 
     /**
      * @param memberId 접속한 사용자 아이디
-     * @param cursorId 커서 아이디
      * @param category 없을 경우 전체 카테고리 조회
+     * @param cursorPageReq 커서 페이지 요청
      * @return ''
      */
-    List<SpaceWithMemberCount> findAllSpacesByMemberIdAndCategoryAndCursor(Long memberId, Long cursorId, Optional<SpaceCategory> category, int pageSize);
+    CursorPageRes<SpaceWithMemberCount> findAllSpacesByMemberIdAndCategoryAndCursor(Long memberId, SpaceCategory category, CursorPageReq cursorPageReq);
+
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepository.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepository.java
@@ -2,14 +2,30 @@ package org.layer.domain.space.repository;
 
 import static org.layer.global.exception.SpaceExceptionType.*;
 
+import java.util.List;
+
+import org.layer.domain.space.dto.SpaceWithRetrospectCount;
 import org.layer.domain.space.entity.Space;
 import org.layer.domain.space.exception.SpaceException;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Query;
 
 public interface SpaceRepository extends JpaRepository<Space, Long>, SpaceCustomRepository {
     default Space findByIdOrThrow(Long spaceId) {
         return findById(spaceId)
                 .orElseThrow(() -> new SpaceException(NOT_FOUND_SPACE));
     }
+
+    @Query("""
+        SELECT new org.layer.domain.space.dto.SpaceWithRetrospectCount(
+            s.id,
+            COUNT(r.id),
+            COUNT(CASE WHEN r.status = 'PROCEEDING' THEN 1 END)
+        )
+        FROM Space s
+        LEFT JOIN s.retrospectList r
+        WHERE s.id IN :spaceIds
+        GROUP BY s.id
+    """)
+    List<SpaceWithRetrospectCount> findAllSpaceWithRetrospectCount(List<Long> spaceIds);
 }

--- a/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
+++ b/layer-domain/src/main/java/org/layer/domain/space/repository/SpaceRepositoryImpl.java
@@ -1,22 +1,20 @@
 package org.layer.domain.space.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
-import org.layer.domain.space.dto.QSpaceMember;
+
+import org.layer.common.dto.CursorPageReq;
+import org.layer.common.dto.CursorPageRes;
 import org.layer.domain.space.dto.QSpaceWithMemberCount;
-import org.layer.domain.space.dto.SpaceMember;
 import org.layer.domain.space.dto.SpaceWithMemberCount;
 import org.layer.domain.space.entity.QMemberSpaceRelation;
 import org.layer.domain.space.entity.SpaceCategory;
-import org.layer.domain.space.entity.SpaceField;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.layer.domain.form.entity.QForm.form;
 import static org.layer.domain.member.entity.QMember.member;
@@ -27,56 +25,55 @@ import static org.layer.domain.space.entity.QSpace.space;
 @Slf4j
 public class SpaceRepositoryImpl implements SpaceCustomRepository {
 
-    private final JPAQueryFactory queryFactory;
+	private final JPAQueryFactory queryFactory;
 
-    public SpaceRepositoryImpl(EntityManager em) {
-        this.queryFactory = new JPAQueryFactory(em);
-    }
+	public SpaceRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+	}
 
-    @Override
-    public List<SpaceWithMemberCount> findAllSpacesByMemberIdAndCategoryAndCursor(Long memberId, Long cursorId, Optional<SpaceCategory> category, int pageSize) {
-        BooleanExpression predicate = memberSpaceRelation.memberId.eq(memberId)
-                .and(cursorId == 0 ? null : space.id.lt(cursorId))
-                .and(hasCategory(category));
+	@Override
+	public CursorPageRes<SpaceWithMemberCount> findAllSpacesByMemberIdAndCategoryAndCursor(
+		Long memberId, SpaceCategory category, CursorPageReq cursorPageReq
+	) {
+		QMemberSpaceRelation msrUser = memberSpaceRelation;
+		QMemberSpaceRelation msrAll = new QMemberSpaceRelation("msr_all");
 
-        return getSpaceWithMemberCountQuery()
-                .where(predicate)
-                .groupBy(space.id)
-                .limit(pageSize + 1)
-                .fetch();
-    }
+		BooleanExpression isMemberInSpace = msrUser.memberId.eq(memberId);
+		BooleanExpression hasCursor = cursorPageReq.isFirstPage() ? null : space.id.lt(cursorPageReq.getCursorId());
+		BooleanExpression hasCategory = category == null ? null : space.category.eq(category);
+		BooleanExpression isLeaderNotDeleted = member.deletedAt.isNull();
 
-    private BooleanExpression hasCategory(Optional<SpaceCategory> category) {
-        return category.map(space.category::eq).orElse(null);
-    }
+		List<SpaceWithMemberCount> data = queryFactory
+			.select(new QSpaceWithMemberCount(
+				space.id,
+				space.createdAt,
+				space.updatedAt,
+				space.category,
+				space.fieldList,
+				space.name,
+				space.introduction,
+				member,
+				space.formId,
+				form.formTag,
+				msrAll.space.id.count().as("memberCount"),
+				space.bannerUrl
+			))
+			.from(msrUser)
+			.leftJoin(space).on(space.id.eq(msrUser.space.id))
+			.leftJoin(member).on(space.leaderId.eq(member.id))
+			.leftJoin(msrAll).on(msrAll.space.id.eq(space.id))
+			.leftJoin(form).on(space.formId.eq(form.id))
+			.where(
+				isMemberInSpace,
+				hasCursor,
+				hasCategory,
+				isLeaderNotDeleted
+			)
+			.groupBy(space.id)
+			.orderBy(space.createdAt.desc())
+			.limit(cursorPageReq.getFetchSize())
+			.fetch();
 
-    private JPAQuery<SpaceWithMemberCount> getSpaceWithMemberCountQuery() {
-        QMemberSpaceRelation memberCountRelationTable = new QMemberSpaceRelation("msr");
-        return queryFactory.select(
-                        new QSpaceWithMemberCount(
-                                space.id,
-                                space.createdAt,
-                                space.updatedAt,
-                                space.category,
-                                space.fieldList,
-                                space.name,
-                                space.introduction,
-                                member,
-                                space.formId,
-                                form.formTag,
-                                memberCountRelationTable.space.id.count().as("memberCount"),
-                                space.bannerUrl
-                        ))
-                .from(space)
-                .leftJoin(memberSpaceRelation).on(space.id.eq(memberSpaceRelation.space.id))
-                .leftJoin(memberCountRelationTable).on(space.id.eq(memberCountRelationTable.space.id))
-                .leftJoin(member).on(space.leaderId.eq(member.id))
-                .leftJoin(form).on(space.formId.eq(form.id))
-                .leftJoin(member).on(memberSpaceRelation.memberId.eq(member.id)) // memberId와 member의 id 조인
-                .where(member.deletedAt.isNull()) // 삭제되지 않은 회원만
-                .orderBy(space.createdAt.desc())
-                .orderBy(form.id.desc())
-                .limit(1);
-
-    }
+		return new CursorPageRes<>(data, cursorPageReq.getPageSize(), SpaceWithMemberCount::getId);
+	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현 및 수정
- [ ] 버그 수정
- [ ] 레거시 삭제
- [x] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->

### 1. 스페이스 목록 조회 데이터 개선 및 수정
- 요구사항에 따라 응답 데이터를 추가했습니다.
- 기존에는 한 번의 쿼리로 구현하고자 했지만, 기존에도 복잡한 쿼리이기 때문에 쿼리의 복잡도가 너무 올라간다고 생각했습니다.
- 그래서 추가적으로 요구된 회고 관련 데이터는 따로 카운트 쿼리를 한 번 더 보내는 방식으로 구현했습니다.
- 같은 VPC 내부에 있기에 네트워크 왕복 비용은 무시할 수 있는 수준이라고 생각해서 큰 문제가 없다고 생각합니다.
- 또한, 커버링 인덱스를 타고 반환되는 데이터 용량도 매우 작기에 DB 성능 측면에서도 큰 문제가 되지 않는다고 생각합니다.

### 2. 커서 기반 페이지네이션 객체
- 커서 기반 페이지네이션 관련 코드가 서비스 로직에 있는 것은 서비스 단에 너무 많은 책임이 있다고 생각했습니다.
- 이를 개선하고자 관련 로직을 하나의 클래스에 몰아넣어 응집화 시켰습니다.

### 3. 쿼리 가독성 개선
- 기존에 스페이스 목록 하기 위한 쿼리가 너무 복잡한 문제가 있었습니다.
- 애초에 요구사항이 복잡하지만, 그럼에도 조금 더 쿼리의 가독성을 높이고자 했습니다.
- 한 눈에 쿼리가 보이도록 조정해봤습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #420 
