### PR TITLE
[admin] feat: 회고 관련 CTR 저장 로직 구현

### DIFF
--- a/layer-admin/src/main/java/org/layer/admin/retrospect/entity/AdminRetrospectImpressionClick.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/entity/AdminRetrospectImpressionClick.java
@@ -1,0 +1,66 @@
+package org.layer.admin.retrospect.entity;
+
+import java.time.LocalDateTime;
+
+import org.layer.admin.retrospect.enums.AdminRetrospectStatus;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+ * 특정 회고의 클릭 이벤트를 저장하는 엔티티
+ * 이 엔티티는 회고 클릭 이벤트를 기록하여, 나중에 회고의 클릭 이력을 추적할 수 있도록 합니다.
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AdminRetrospectImpressionClick {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull
+	private LocalDateTime eventTime;
+
+	@NotNull
+	private Long memberId;
+
+	@NotNull
+	private String eventId;
+
+	@NotNull
+	private Long spaceId;
+
+	@NotNull
+	private Long retrospectId;
+
+	@NotNull
+	@Enumerated(value = EnumType.STRING)
+	private AdminRetrospectStatus retrospectStatus;
+
+	@Builder
+	private AdminRetrospectImpressionClick(
+		LocalDateTime eventTime,
+		Long memberId,
+		String eventId,
+		Long spaceId,
+		Long retrospectId,
+		AdminRetrospectStatus retrospectStatus
+	) {
+		this.eventTime = eventTime;
+		this.memberId = memberId;
+		this.eventId = eventId;
+		this.spaceId = spaceId;
+		this.retrospectId = retrospectId;
+		this.retrospectStatus = retrospectStatus;
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/enums/AdminRetrospectStatus.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/enums/AdminRetrospectStatus.java
@@ -1,5 +1,9 @@
 package org.layer.admin.retrospect.enums;
 
 public enum AdminRetrospectStatus {
-	NOT_STARTED, PROCEEDING, DONE
+	PROCEEDING, DONE;
+
+	public static AdminRetrospectStatus from(String status) {
+		return AdminRetrospectStatus.valueOf(status.toUpperCase());
+	}
 }

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/enums/AdminRetrospectStatus.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/enums/AdminRetrospectStatus.java
@@ -1,0 +1,5 @@
+package org.layer.admin.retrospect.enums;
+
+public enum AdminRetrospectStatus {
+	NOT_STARTED, PROCEEDING, DONE
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/listener/RetrospectClickEventListener.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/listener/RetrospectClickEventListener.java
@@ -1,0 +1,21 @@
+package org.layer.admin.retrospect.listener;
+
+import org.layer.admin.common.UserOnlyEventListener;
+import org.layer.admin.retrospect.service.AdminRetrospectService;
+import org.layer.event.retrospect.ClickRetrospectEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RetrospectClickEventListener {
+	private final AdminRetrospectService adminRetrospectService;
+
+	@UserOnlyEventListener
+	@EventListener
+	public void handleClickRetrospectEvent(ClickRetrospectEvent event) {
+		adminRetrospectService.saveRetrospectImpressionClick(event);
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/repository/AdminRetrospectImpressionClickRepository.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/repository/AdminRetrospectImpressionClickRepository.java
@@ -1,0 +1,7 @@
+package org.layer.admin.retrospect.repository;
+
+import org.layer.admin.retrospect.entity.AdminRetrospectImpressionClick;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRetrospectImpressionClickRepository extends JpaRepository<AdminRetrospectImpressionClick, Long> {
+}

--- a/layer-admin/src/main/java/org/layer/admin/retrospect/service/AdminRetrospectService.java
+++ b/layer-admin/src/main/java/org/layer/admin/retrospect/service/AdminRetrospectService.java
@@ -23,12 +23,16 @@ import org.layer.admin.retrospect.controller.dto.RetrospectRetentionResponse;
 import org.layer.admin.retrospect.controller.dto.RetrospectStayTimeResponse;
 import org.layer.admin.retrospect.entity.AdminRetrospectAnswerHistory;
 import org.layer.admin.retrospect.entity.AdminRetrospectHistory;
+import org.layer.admin.retrospect.entity.AdminRetrospectImpressionClick;
+import org.layer.admin.retrospect.enums.AdminRetrospectStatus;
 import org.layer.admin.retrospect.enums.AnswerTimeRange;
 import org.layer.admin.retrospect.repository.AdminRetrospectAnswerRepository;
+import org.layer.admin.retrospect.repository.AdminRetrospectImpressionClickRepository;
 import org.layer.admin.retrospect.repository.AdminRetrospectRepository;
 import org.layer.admin.retrospect.repository.dto.RetrospectAnswerCompletionDto;
 import org.layer.admin.retrospect.repository.dto.SpaceRetrospectCountDto;
 import org.layer.admin.space.repository.AdminSpaceRepository;
+import org.layer.event.retrospect.ClickRetrospectEvent;
 import org.layer.event.retrospect.CreateRetrospectEvent;
 import org.layer.event.retrospect.AnswerRetrospectEndEvent;
 import org.layer.event.retrospect.AnswerRetrospectStartEvent;
@@ -44,6 +48,7 @@ public class AdminRetrospectService {
 
 	private final AdminRetrospectRepository adminRetrospectRepository;
 	private final AdminRetrospectAnswerRepository adminRetrospectAnswerRepository;
+	private final AdminRetrospectImpressionClickRepository adminRetrospectImpressionClickRepository;
 	private final AdminMemberRepository adminMemberRepository;
 	private final AdminSpaceRepository adminSpaceRepository;
 
@@ -265,5 +270,21 @@ public class AdminRetrospectService {
 			.build();
 
 		adminRetrospectRepository.save(retrospectHistory);
+	}
+
+	@Transactional(propagation = REQUIRES_NEW)
+	@Async
+	public void saveRetrospectImpressionClick(ClickRetrospectEvent event) {
+
+		AdminRetrospectImpressionClick clickEvent = AdminRetrospectImpressionClick.builder()
+			.eventTime(event.eventTime())
+			.memberId(event.memberId())
+			.eventId(event.eventId())
+			.spaceId(event.spaceId())
+			.retrospectId(event.retrospectId())
+			.retrospectStatus(AdminRetrospectStatus.from(event.retrospectStatus()))
+			.build();
+
+		adminRetrospectImpressionClickRepository.save(clickEvent);
 	}
 }

--- a/layer-admin/src/main/java/org/layer/admin/space/entity/AdminSpaceImpressionClick.java
+++ b/layer-admin/src/main/java/org/layer/admin/space/entity/AdminSpaceImpressionClick.java
@@ -1,0 +1,61 @@
+package org.layer.admin.space.entity;
+
+import java.time.LocalDateTime;
+
+import org.layer.admin.retrospect.enums.AdminRetrospectStatus;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+ * 특정 스페이스의 클릭 이벤트를 저장하는 엔티티
+ * 이 엔티티는 스페이스 클릭 이벤트를 기록하여, 나중에 스페이스의 클릭 이력을 추적할 수 있도록 합니다.
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AdminSpaceImpressionClick {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull
+	private LocalDateTime eventTime;
+
+	@NotNull
+	private Long memberId;
+
+	@NotNull
+	private String eventId;
+
+	@NotNull
+	private Long spaceId;
+
+	@NotNull
+	@Enumerated(value = EnumType.STRING)
+	private AdminRetrospectStatus retrospectStatus;
+
+	@Builder
+	private AdminSpaceImpressionClick(
+		LocalDateTime eventTime,
+		Long memberId,
+		String eventId,
+		Long spaceId,
+		AdminRetrospectStatus retrospectStatus
+	) {
+		this.eventTime = eventTime;
+		this.memberId = memberId;
+		this.eventId = eventId;
+		this.spaceId = spaceId;
+		this.retrospectStatus = retrospectStatus;
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/space/listener/SpaceClickEventListener.java
+++ b/layer-admin/src/main/java/org/layer/admin/space/listener/SpaceClickEventListener.java
@@ -1,0 +1,21 @@
+package org.layer.admin.space.listener;
+
+import org.layer.admin.common.UserOnlyEventListener;
+import org.layer.admin.space.service.AdminSpaceService;
+import org.layer.event.space.ClickSpaceEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SpaceClickEventListener {
+	private final AdminSpaceService adminSpaceService;
+
+	@UserOnlyEventListener
+	@EventListener
+	public void handleClickSpaceEvent(ClickSpaceEvent event) {
+		adminSpaceService.saveSpaceImpressionClick(event);
+	}
+}

--- a/layer-admin/src/main/java/org/layer/admin/space/repository/AdminSpaceImpressionClickRepository.java
+++ b/layer-admin/src/main/java/org/layer/admin/space/repository/AdminSpaceImpressionClickRepository.java
@@ -1,0 +1,7 @@
+package org.layer.admin.space.repository;
+
+import org.layer.admin.space.entity.AdminSpaceImpressionClick;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminSpaceImpressionClickRepository extends JpaRepository<AdminSpaceImpressionClick, Long> {
+}

--- a/layer-admin/src/main/java/org/layer/admin/space/service/AdminSpaceService.java
+++ b/layer-admin/src/main/java/org/layer/admin/space/service/AdminSpaceService.java
@@ -5,14 +5,18 @@ import static org.springframework.transaction.annotation.Propagation.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.layer.admin.retrospect.enums.AdminRetrospectStatus;
 import org.layer.admin.space.controller.dto.SpaceCountResponse;
 import org.layer.admin.space.controller.dto.TeamSpaceRatioPerMemberDto;
 import org.layer.admin.space.controller.dto.TeamSpaceRatioResponse;
 import org.layer.admin.space.entity.AdminMemberSpaceHistory;
 import org.layer.admin.space.entity.AdminSpaceHistory;
+import org.layer.admin.space.entity.AdminSpaceImpressionClick;
 import org.layer.admin.space.enums.AdminSpaceCategory;
 import org.layer.admin.space.repository.AdminMemberSpaceRepository;
+import org.layer.admin.space.repository.AdminSpaceImpressionClickRepository;
 import org.layer.admin.space.repository.AdminSpaceRepository;
+import org.layer.event.space.ClickSpaceEvent;
 import org.layer.event.space.CreateSpaceEvent;
 import org.layer.event.space.JoinSpaceEvent;
 import org.layer.event.space.LeaveSpaceEvent;
@@ -30,6 +34,7 @@ public class AdminSpaceService {
 
 	private final AdminSpaceRepository adminSpaceRepository;
 	private final AdminMemberSpaceRepository adminMemberSpaceRepository;
+	private final AdminSpaceImpressionClickRepository adminSpaceImpressionClickRepository;
 
 	public List<SpaceCountResponse> getSpaceCount(LocalDateTime startDate, LocalDateTime endDate) {
 		return adminSpaceRepository.findAllByCategory(startDate, endDate);
@@ -83,5 +88,19 @@ public class AdminSpaceService {
 	public void deleteMemberSpaceHistory(LeaveSpaceEvent event) {
 		adminMemberSpaceRepository.deleteByMemberIdAndSpaceId(
 			event.memberId(), event.spaceId());
+	}
+
+	@Transactional(propagation = REQUIRES_NEW)
+	@Async
+	public void saveSpaceImpressionClick(ClickSpaceEvent event) {
+		AdminSpaceImpressionClick impressionClick = AdminSpaceImpressionClick.builder()
+			.eventId(event.eventId())
+			.eventTime(event.eventTime())
+			.memberId(event.memberId())
+			.spaceId(event.spaceId())
+			.retrospectStatus(AdminRetrospectStatus.from(event.retrospectStatus()))
+			.build();
+
+		adminSpaceImpressionClickRepository.save(impressionClick);
 	}
 }

--- a/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
+++ b/layer-api/src/main/java/org/layer/domain/answer/service/AnswerService.java
@@ -175,7 +175,7 @@ public class AnswerService {
 		team.validateTeamMembership(memberId);
 
 		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
-		retrospect.isProceedingRetrospect();
+		retrospect.validateProceedingRetrospect();
 
 		// 임시 답변을 했는지 검증
 		Answers answers = new Answers(
@@ -233,7 +233,7 @@ public class AnswerService {
 		team.validateTeamMembership(memberId);
 
 		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
-		retrospect.isProceedingRetrospect();
+		retrospect.validateProceedingRetrospect();
 
 		// 완료된 답변 검증
 		Answers answers = new Answers(

--- a/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
+++ b/layer-api/src/main/java/org/layer/domain/question/service/QuestionService.java
@@ -45,7 +45,7 @@ public class QuestionService {
 
 		// 해당 회고가 있는지, PROCEEDING 상태인지 검증
 		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
-		retrospect.isProceedingRetrospect();
+		retrospect.validateProceedingRetrospect();
 
 		List<Question> questions = questionRepository.findAllByRetrospectIdAndQuestionOwnerOrderByQuestionOrder(
 			retrospectId, QuestionOwner.TEAM);

--- a/layer-api/src/main/java/org/layer/domain/stats/StatsRetrospectApi.java
+++ b/layer-api/src/main/java/org/layer/domain/stats/StatsRetrospectApi.java
@@ -1,0 +1,14 @@
+package org.layer.domain.stats;
+
+import org.layer.annotation.MemberId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "📊어드민")
+public interface StatsRetrospectApi {
+	@Operation(summary = "회고 클릭 이벤트", description = "특정 회고 클릭했을 때 해당 API를 호출합니다.")
+	ResponseEntity<Void> clickSpace(@PathVariable Long retrospectId, @MemberId Long memberId);
+}

--- a/layer-api/src/main/java/org/layer/domain/stats/StatsRetrospectController.java
+++ b/layer-api/src/main/java/org/layer/domain/stats/StatsRetrospectController.java
@@ -1,0 +1,25 @@
+package org.layer.domain.stats;
+
+import org.layer.annotation.MemberId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class StatsRetrospectController implements StatsRetrospectApi {
+
+	private final StatsRetrospectService statsRetrospectService;
+
+	@Override
+	@PostMapping("/stats/retrospects/{retrospectId}/click")
+	public ResponseEntity<Void> clickSpace(@PathVariable Long retrospectId, @MemberId Long memberId){
+
+		statsRetrospectService.clickRetrospect(retrospectId, memberId);
+
+		return ResponseEntity.ok().body(null);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/stats/StatsRetrospectService.java
+++ b/layer-api/src/main/java/org/layer/domain/stats/StatsRetrospectService.java
@@ -1,0 +1,66 @@
+package org.layer.domain.stats;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.layer.domain.common.random.CustomRandom;
+import org.layer.domain.common.time.Time;
+import org.layer.domain.retrospect.entity.Retrospect;
+import org.layer.domain.retrospect.entity.RetrospectStatus;
+import org.layer.domain.retrospect.repository.RetrospectRepository;
+import org.layer.event.retrospect.ClickRetrospectEvent;
+import org.layer.event.space.ClickSpaceEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StatsRetrospectService {
+	private final RetrospectRepository retrospectRepository;
+
+	private final ApplicationEventPublisher eventPublisher;
+	private final CustomRandom random;
+	private final Time time;
+
+	public void clickSpace(Long spaceId, Long memberId) {
+
+		List<Retrospect> retrospects = retrospectRepository.findAllBySpaceId(spaceId);
+		if(retrospects.isEmpty()) {
+			return;
+		}
+
+		Optional<Retrospect> proceedingRetrospect = retrospects.stream()
+			.filter(Retrospect::isRetrospectProceeding)
+			.findFirst();
+
+		RetrospectStatus retrospectStatus = null;
+		 if(proceedingRetrospect.isEmpty()) {
+			retrospectStatus = RetrospectStatus.DONE;
+		} else {
+			retrospectStatus = RetrospectStatus.PROCEEDING;
+		}
+
+		eventPublisher.publishEvent(new ClickSpaceEvent(
+			random.generateRandomValue(),
+			memberId,
+			time.now(),
+			spaceId,
+			retrospectStatus.name()
+		));
+	}
+
+	public void clickRetrospect(Long retrospectId, Long memberId) {
+		Retrospect retrospect = retrospectRepository.findByIdOrThrow(retrospectId);
+
+		eventPublisher.publishEvent(new ClickRetrospectEvent(
+			random.generateRandomValue(),
+			memberId,
+			time.now(),
+			retrospect.getSpaceId(),
+			retrospectId,
+			retrospect.getRetrospectStatus().name()
+		));
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/stats/StatsSpaceApi.java
+++ b/layer-api/src/main/java/org/layer/domain/stats/StatsSpaceApi.java
@@ -1,0 +1,14 @@
+package org.layer.domain.stats;
+
+import org.layer.annotation.MemberId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "📊어드민")
+public interface StatsSpaceApi {
+	@Operation(summary = "스페이스 클릭 이벤트", description = "특정 스페이스 클릭했을 때 해당 API를 호출합니다.")
+	ResponseEntity<Void> clickSpace(@PathVariable Long spaceId, @MemberId Long memberId);
+}

--- a/layer-api/src/main/java/org/layer/domain/stats/StatsSpaceController.java
+++ b/layer-api/src/main/java/org/layer/domain/stats/StatsSpaceController.java
@@ -1,0 +1,25 @@
+package org.layer.domain.stats;
+
+import org.layer.annotation.MemberId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class StatsSpaceController implements StatsSpaceApi {
+
+	private final StatsRetrospectService statsRetrospectService;
+
+	@Override
+	@PostMapping("/stats/spaces/{spaceId}/click")
+	public ResponseEntity<Void> clickSpace(@PathVariable Long spaceId, @MemberId Long memberId){
+
+		statsRetrospectService.clickSpace(spaceId, memberId);
+
+		return ResponseEntity.ok().body(null);
+	}
+}

--- a/layer-api/src/main/java/org/layer/domain/stats/StatsTemplateApi.java
+++ b/layer-api/src/main/java/org/layer/domain/stats/StatsTemplateApi.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "[어드민] 템플릿 관련", description = "템플릿 관련한 어드민 기능 API")
+@Tag(name = "📊어드민", description = "어드민 API")
 public interface StatsTemplateApi {
 
 	@Operation(summary = "템플릿 리스트 보기 클릭 이벤트", description = "템플릿 리스트 보기를 클릭했을 때 해당 API를 호출합니다.")

--- a/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
+++ b/layer-domain/src/main/java/org/layer/domain/retrospect/entity/Retrospect.java
@@ -58,7 +58,11 @@ public class Retrospect extends BaseTimeEntity {
 		this.deadline = deadline;
 	}
 
-	public void isProceedingRetrospect() {
+	public boolean isRetrospectProceeding() {
+		return this.retrospectStatus.equals(RetrospectStatus.PROCEEDING);
+	}
+
+	public void validateProceedingRetrospect() {
 		if (!this.retrospectStatus.equals(RetrospectStatus.PROCEEDING)) {
 			throw new RetrospectException(NOT_PROCEEDING_RETROSPECT);
 		}
@@ -97,24 +101,12 @@ public class Retrospect extends BaseTimeEntity {
 	}
 
 	public void updateRetrospectStatus(RetrospectStatus retrospectStatus) {
-		isProceedingRetrospect();
+		validateProceedingRetrospect();
 
 		this.retrospectStatus = retrospectStatus;
 	}
 
 	public void updateAnalysisStatus(AnalysisStatus analysisStatus) {
 		this.analysisStatus = analysisStatus;
-	}
-
-	public boolean hasDeadLine() {
-		if (this.deadline == null) {
-			return false;
-		}
-
-		return true;
-	}
-
-	public void updateDeadLine(LocalDateTime deadline){
-		this.deadline = deadline;
 	}
 }

--- a/layer-domain/src/test/java/org/layer/domain/retrospect/entity/RetrospectTest.java
+++ b/layer-domain/src/test/java/org/layer/domain/retrospect/entity/RetrospectTest.java
@@ -14,7 +14,7 @@ class RetrospectTest {
 			LocalDateTime.of(2024, 8, 4, 3, 5));
 
 		// when
-		retrospect.isProceedingRetrospect();
+		retrospect.validateProceedingRetrospect();
 
 		Assertions.assertThat(retrospect.getRetrospectStatus()).isEqualTo(RetrospectStatus.PROCEEDING);
 	}

--- a/layer-event/src/main/java/org/layer/event/retrospect/ClickRetrospectEvent.java
+++ b/layer-event/src/main/java/org/layer/event/retrospect/ClickRetrospectEvent.java
@@ -1,0 +1,16 @@
+package org.layer.event.retrospect;
+
+import java.time.LocalDateTime;
+
+import org.layer.event.BaseEvent;
+
+public record ClickRetrospectEvent(
+	String eventId,
+	Long memberId,
+	LocalDateTime eventTime,
+	Long spaceId,
+	Long retrospectId,
+	String retrospectStatus
+
+) implements BaseEvent {
+}

--- a/layer-event/src/main/java/org/layer/event/space/ClickSpaceEvent.java
+++ b/layer-event/src/main/java/org/layer/event/space/ClickSpaceEvent.java
@@ -1,0 +1,14 @@
+package org.layer.event.space;
+
+import java.time.LocalDateTime;
+
+import org.layer.event.BaseEvent;
+
+public record ClickSpaceEvent(
+	String eventId,
+	Long memberId,
+	LocalDateTime eventTime,
+	Long spaceId,
+	String retrospectStatus
+) implements BaseEvent {
+}


### PR DESCRIPTION
## 📝 PR 타입
- [X] 기능 구현 및 수정
- [ ] 버그 수정
- [ ] 레거시 삭제
- [ ] 리팩토링
- [ ] 인프라
- [ ] docs 작업, swagger 작업
- [ ] 테스트 코드 작성

## 📢 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회고 스페이스와 회고에 대한 CTR 관련 저장 로직을 구현했습니다.

## ❗️To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->


## ⚙️ 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 발생한 쿼리 첨부


## 👉 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #430 
